### PR TITLE
fix: show app settings fields

### DIFF
--- a/app.json
+++ b/app.json
@@ -111,7 +111,7 @@
     {
       "id": "sip_domain",
       "type": "text",
-      "title": {
+      "label": {
         "en": "SIP Domain/Registrar",
         "nl": "SIP Domein/Registrar"
       }
@@ -119,7 +119,7 @@
     {
       "id": "sip_proxy",
       "type": "text",
-      "title": {
+      "label": {
         "en": "SIP Proxy/Request-URI host (optional)",
         "nl": "SIP Proxy/Request-URI host (optioneel)"
       }
@@ -127,7 +127,7 @@
     {
       "id": "username",
       "type": "text",
-      "title": {
+      "label": {
         "en": "Username",
         "nl": "Gebruikersnaam"
       }
@@ -135,7 +135,7 @@
     {
       "id": "password",
       "type": "password",
-      "title": {
+      "label": {
         "en": "Password",
         "nl": "Wachtwoord"
       }
@@ -143,7 +143,7 @@
     {
       "id": "display_name",
       "type": "text",
-      "title": {
+      "label": {
         "en": "Display name (From)",
         "nl": "Weergavenaam (From)"
       },
@@ -152,7 +152,7 @@
     {
       "id": "from_user",
       "type": "text",
-      "title": {
+      "label": {
         "en": "From user",
         "nl": "From user"
       }
@@ -160,7 +160,7 @@
     {
       "id": "local_ip",
       "type": "text",
-      "title": {
+      "label": {
         "en": "Local IP (Homey)",
         "nl": "Lokaal IP (Homey)"
       }
@@ -168,7 +168,7 @@
     {
       "id": "local_sip_port",
       "type": "number",
-      "title": {
+      "label": {
         "en": "Local SIP port",
         "nl": "Lokale SIP poort"
       },
@@ -177,7 +177,7 @@
     {
       "id": "local_rtp_port",
       "type": "number",
-      "title": {
+      "label": {
         "en": "Local RTP port",
         "nl": "Lokale RTP poort"
       },
@@ -186,7 +186,7 @@
     {
       "id": "expires_sec",
       "type": "number",
-      "title": {
+      "label": {
         "en": "REGISTER Expires (s)",
         "nl": "REGISTER Expires (s)"
       },
@@ -195,7 +195,7 @@
     {
       "id": "invite_timeout",
       "type": "number",
-      "title": {
+      "label": {
         "en": "Invite timeout (s)",
         "nl": "Invite timeout (s)"
       },


### PR DESCRIPTION
## Summary
- use `label` instead of `title` for SIP configuration options so they appear in the Homey app settings

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b039147f6c8330bf7836f4f62141c0