### PR TITLE
Add configurable SIP settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # com.homey.phonehome
-Voip Support voor Homey
+
+VOIP Support voor Homey.
+
+Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, wachtwoord en poorten naar wens aanpasbaar zijn.

--- a/settings/index.html
+++ b/settings/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>VOIP Settings</title>
+  <script src="/homey.js" data-origin="settings"></script>
+  <style>
+    body { font-family: sans-serif; margin: 20px; }
+    label { display: block; margin-top: 10px; }
+    input { width: 100%; box-sizing: border-box; }
+    button { margin-top: 20px; }
+  </style>
+</head>
+<body>
+  <h1>SIP Settings</h1>
+  <form id="settings-form">
+    <label>SIP Domain/Registrar
+      <input id="sip_domain" type="text" />
+    </label>
+    <label>SIP Proxy/Request-URI host (optional)
+      <input id="sip_proxy" type="text" />
+    </label>
+    <label>Username
+      <input id="username" type="text" />
+    </label>
+    <label>Password
+      <input id="password" type="password" />
+    </label>
+    <label>Display name (From)
+      <input id="display_name" type="text" />
+    </label>
+    <label>From user
+      <input id="from_user" type="text" />
+    </label>
+    <label>Local IP (Homey)
+      <input id="local_ip" type="text" />
+    </label>
+    <label>Local SIP port
+      <input id="local_sip_port" type="number" />
+    </label>
+    <label>Local RTP port
+      <input id="local_rtp_port" type="number" />
+    </label>
+    <label>REGISTER Expires (s)
+      <input id="expires_sec" type="number" />
+    </label>
+    <label>Invite timeout (s)
+      <input id="invite_timeout" type="number" />
+    </label>
+    <button type="submit">Save</button>
+  </form>
+  <script>
+    function onHomeyReady(Homey) {
+      const fields = ['sip_domain','sip_proxy','username','password','display_name','from_user','local_ip','local_sip_port','local_rtp_port','expires_sec','invite_timeout'];
+      fields.forEach(key => {
+        Homey.get(key, (err, value) => {
+          if (!err && document.getElementById(key)) {
+            document.getElementById(key).value = value !== undefined && value !== null ? value : '';
+          }
+        });
+      });
+      document.getElementById('settings-form').addEventListener('submit', e => {
+        e.preventDefault();
+        fields.forEach(key => {
+          const input = document.getElementById(key);
+          let val = input.value;
+          if (input.type === 'number') {
+            val = Number(val);
+            if (isNaN(val)) val = 0;
+          }
+          Homey.set(key, val, err => {
+            if (err) console.error(err);
+          });
+        });
+        Homey.alert('Settings saved');
+      });
+      Homey.ready();
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add settings page to configure SIP credentials and ports
- Document SIP configuration in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b03ab4145c8330b7a4014a6f075a53