### PR TITLE
Handle padded WAV chunks and truncated data

### DIFF
--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -9,11 +9,11 @@ function readWavPcm16Mono8k(path) {
   let offset = 12;
   let fmt, data;
   while (offset < buf.length) {
-    const id = buf.slice(offset, offset+4).toString();
-    const size = buf.readUInt32LE(offset+4);
+    const id = buf.slice(offset, offset + 4).toString();
+    const size = buf.readUInt32LE(offset + 4);
     if (id === 'fmt ') fmt = { offset: offset + 8, size };
     if (id === 'data') data = { offset: offset + 8, size };
-    offset += 8 + size;
+    offset += 8 + size + (size % 2); // chunks are padded to even length
   }
   if (!fmt || !data) throw new Error('fmt of data chunk ontbreekt');
   const audioFormat   = buf.readUInt16LE(fmt.offset + 0);
@@ -25,9 +25,12 @@ function readWavPcm16Mono8k(path) {
   if (sampleRate !== 8000) throw new Error('8000 Hz vereist');
   if (bitsPerSample !== 16) throw new Error('16-bit PCM vereist');
 
-  const samples = data.size / 2;
+  const available = Math.max(0, Math.min(data.size, buf.length - data.offset));
+  const samples = Math.floor(available / 2);
   const pcm = new Int16Array(samples);
-  for (let i=0;i<samples;i++) pcm[i] = buf.readInt16LE(data.offset + i*2);
+  for (let i = 0; i < samples; i++) {
+    pcm[i] = buf.readInt16LE(data.offset + i * 2);
+  }
   return pcm;
 }
 


### PR DESCRIPTION
## Summary
- handle odd-sized WAV chunks by skipping padding
- avoid reading past end of buffer when parsing WAV

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b040faea9883309cc9269760254d98