### PR TITLE
Handle SIP socket bind errors

### DIFF
--- a/lib/minisip.js
+++ b/lib/minisip.js
@@ -24,12 +24,18 @@ class MiniSip {
     this._reqListeners = [];
   }
 
-  start({ address, port }) {
+  async start({ address, port }) {
     this.address = address;
     this.port = port;
     this.sock = dgram.createSocket('udp4');
     this.sock.on('message', (msg, rinfo) => this._onMessage(msg, rinfo));
-    this.sock.bind(port, address);
+    await new Promise((resolve, reject) => {
+      this.sock.once('error', err => {
+        this.stop();
+        reject(err);
+      });
+      this.sock.bind(port, address, resolve);
+    });
   }
 
   stop() {

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -87,7 +87,7 @@ async function callOnce(cfg) {
   const reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
 
   logger('info', `REGISTER naar ${sip_domain} als ${username}`);
-  sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
+  await sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
 
   const baseReq = (method, uri, extraHeaders = {}, content = '') => {
     const callId = genCallId(local_ip);


### PR DESCRIPTION
## Summary
- handle UDP bind errors in MiniSip by awaiting socket binding and cleaning up on failure
- await MiniSip start in SIP call flow to surface bind errors cleanly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "const sip=require('./lib/minisip'); sip.start({address:'192.0.2.1', port:5060}).catch(err=>{console.error('caught', err.code);});"`
- `node -e "const sip=require('./lib/minisip'); sip.start({address:'0.0.0.0', port:5061}).then(()=>{console.log('ok'); sip.stop();});"`


------
https://chatgpt.com/codex/tasks/task_e_68b041e98b388330ad3b4de665e5fbe1