### PR TITLE
Improve SIP bind error logging

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -87,7 +87,16 @@ async function callOnce(cfg) {
   const reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
 
   logger('info', `REGISTER naar ${sip_domain} als ${username}`);
-  await sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
+  logger('info', `Start SIP socket op ${local_ip}:${local_sip_port}`);
+  try {
+    await sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
+  } catch (err) {
+    logger('error', `Kon SIP-poort niet binden op ${local_ip}:${local_sip_port}: ${err.code || err.message || err}`);
+    if (err && err.code === 'EADDRINUSE') {
+      logger('error', 'Poort al in gebruik? Controleer andere processen of pas de "local_sip_port" instelling aan.');
+    }
+    throw err;
+  }
 
   const baseReq = (method, uri, extraHeaders = {}, content = '') => {
     const callId = genCallId(local_ip);


### PR DESCRIPTION
## Summary
- log detailed messages before starting SIP socket
- add error logs when SIP port is already in use

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68b0446528f08330a12295b40c1932c9