### PR TITLE
Improve SIP bind error logging

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -87,7 +87,16 @@ async function callOnce(cfg) {
   const reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
 
   logger('info', `REGISTER naar ${sip_domain} als ${username}`);
-  await sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
+  logger('info', `Start SIP socket op ${local_ip}:${local_sip_port}`);
+  try {
+    await sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
+  } catch (err) {
+    logger('error', `Kon SIP-poort niet binden op ${local_ip}:${local_sip_port}: ${err.code || err.message || err}`);
+    if (err && err.code === 'EADDRINUSE') {
+      logger('error', 'Poort al in gebruik? Controleer andere processen of pas de "local_sip_port" instelling aan.');
+    }
+    throw err;
+  }
 
   const baseReq = (method, uri, extraHeaders = {}, content = '') => {
     const callId = genCallId(local_ip);
@@ -114,16 +123,28 @@ async function callOnce(cfg) {
       contact: [{ uri: contactUri, params: { expires: String(expires_sec) } }],
       expires: expires_sec
     });
+    logger('info', 'Send REGISTER');
     sip.send(register, (res) => {
-      if (res.status === 200) return resolve();
+      logger('info', `REGISTER response: ${res.status} ${res.reason || ''}`);
+      if (res.status === 200) {
+        logger('info', 'REGISTER 200 OK');
+        return resolve();
+      }
       if (res.status === 401 || res.status === 407) {
+        logger('info', `REGISTER challenge: ${res.status}`);
         const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
         const auth = buildAuthHeader(hdr, { method: 'REGISTER', uri: register.uri }, username, password);
         const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
         const r2 = { ...register };
         r2.headers = { ...register.headers, [hdrName]: auth, cseq: { method: 'REGISTER', seq: 2 } };
-        sip.send(r2, res2 => res2.status === 200 ? resolve() : reject(new Error('REGISTER failed: ' + res2.status)));
-      } else reject(new Error('REGISTER failed: ' + res.status));
+        logger('info', 'Send REGISTER with auth');
+        sip.send(r2, res2 => {
+          logger('info', `REGISTER with auth response: ${res2.status} ${res2.reason || ''}`);
+          res2.status === 200 ? resolve() : reject(new Error('REGISTER failed: ' + res2.status));
+        });
+      } else {
+        reject(new Error('REGISTER failed: ' + res.status));
+      }
     });
   });
 
@@ -164,6 +185,7 @@ async function callOnce(cfg) {
           contact: invite.headers.contact
         }
       };
+      logger('info', 'Send ACK');
       sip.send(ack);
       answerTs = Date.now();
       logger('info', `Answered. RTP -> ${remote.ip}:${remote.port}`);
@@ -181,6 +203,7 @@ async function callOnce(cfg) {
             contact: invite.headers.contact
           }
         };
+        logger('info', 'Send BYE');
         sip.send(bye);
         clearTimeout(timer);
         resolve({
@@ -192,18 +215,22 @@ async function callOnce(cfg) {
 
       sip.recv(req => {
         if (req.method === 'BYE') {
+          logger('info', 'Received BYE');
           sip.send(sip.makeResponse(req, 200, 'OK'));
+          logger('info', 'Send 200 OK for BYE');
           endReason = 'Remote BYE';
         }
       });
     };
 
-    const sendInvite = (msg) => {
+    const sendInvite = (msg, isAuth = false) => {
+      logger('info', `Send INVITE${isAuth ? ' with auth' : ''}`);
       sip.send(msg, (res) => {
         if ([100,180,183].includes(res.status)) {
           logger('info', `Progress: ${res.status} ${res.reason || ''}`);
           return;
         }
+        logger('info', `INVITE response: ${res.status} ${res.reason || ''}`);
         if (res.status === 200) return handle2xx(res);
         if (res.status === 486) {
           clearTimeout(timer);
@@ -216,12 +243,13 @@ async function callOnce(cfg) {
           return resolve({ status: 'no-answer', durationMs: 0, reason: endReason });
         }
         if (res.status === 401 || res.status === 407) {
+          logger('info', `INVITE challenge: ${res.status}`);
           const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
           const auth = buildAuthHeader(hdr, { method: 'INVITE', uri: msg.uri }, username, password);
           const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
           const reinvite = { ...msg };
           reinvite.headers = { ...msg.headers, [hdrName]: auth, cseq: { method: 'INVITE', seq: ++cseq } };
-          return sendInvite(reinvite);
+          return sendInvite(reinvite, true);
         }
         clearTimeout(timer);
         endReason = `${res.status} ${res.reason || ''}`;
@@ -232,7 +260,10 @@ async function callOnce(cfg) {
     sendInvite(invite);
   });
 
-  try { sip.stop(); } catch(e) {}
+  try {
+    logger('info', 'Stop SIP socket');
+    sip.stop();
+  } catch(e) {}
   return result;
 }
 


### PR DESCRIPTION
## Summary
- log detailed messages before starting SIP socket
- add error logs when SIP port is already in use
- add logging around all SIP actions (REGISTER, INVITE, ACK, BYE)

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68b0446528f08330a12295b40c1932c9