### PR TITLE
Add SIP name-addr parser

### DIFF
--- a/lib/minisip.js
+++ b/lib/minisip.js
@@ -132,6 +132,37 @@ function hdrTo(obj, name) {
   return `${name}: ${disp}<${obj.uri}>${tag}`;
 }
 
+function parseNameAddr(str) {
+  const result = { params: {} };
+  let rest = str.trim();
+
+  // Match optional display name and URI enclosed in <>
+  const m = rest.match(/^(?:"?([^"<]*)"?\s*)?<([^>]+)>(.*)$/);
+  if (m) {
+    if (m[1]) result.name = m[1].trim();
+    result.uri = m[2].trim();
+    rest = m[3];
+  } else {
+    // No angle brackets, URI is up to first ';'
+    const idx = rest.indexOf(';');
+    if (idx >= 0) {
+      result.uri = rest.slice(0, idx).trim();
+      rest = rest.slice(idx);
+    } else {
+      result.uri = rest.trim();
+      rest = '';
+    }
+  }
+
+  // Parse parameters after URI
+  rest.split(';').filter(Boolean).forEach(part => {
+    const [k, v] = part.split('=');
+    result.params[k.trim()] = v ? v.trim() : true;
+  });
+
+  return result;
+}
+
 function parseHeaders(lines) {
   const headers = {};
   for (const line of lines) {


### PR DESCRIPTION
## Summary
- add parser for SIP name-address headers used in To/From lines

## Testing
- `node -e "require('./lib/minisip')"`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b05c6a159883308115f42e6d901159