### PR TITLE
Add detailed SIP message logging

### DIFF
--- a/lib/minisip.js
+++ b/lib/minisip.js
@@ -20,13 +20,15 @@ class MiniSip {
     this.sock = null;
     this.address = null;
     this.port = null;
+    this.logger = () => {};
     this._respWaiters = []; // {callId, cseqMethod, cb}
     this._reqListeners = [];
   }
 
-  async start({ address, port }) {
+  async start({ address, port, logger }) {
     this.address = address;
     this.port = port;
+    this.logger = logger || (() => {});
     this.sock = dgram.createSocket('udp4');
     this.sock.on('message', (msg, rinfo) => this._onMessage(msg, rinfo));
     await new Promise((resolve, reject) => {
@@ -68,6 +70,7 @@ class MiniSip {
   send(req, cb) {
     const dest = parseUriToHostPort(req.uri);
     const raw = buildRawRequest(req, this.address, this.port);
+    this.logger('debug', `SIP send to ${dest.host}:${dest.port}\n${raw}`);
     const waiter = { callId: req.headers['call-id'], cseqMethod: req.method, cb };
     if (cb) this._respWaiters.push(waiter);
     this.sock.send(Buffer.from(raw, 'utf8'), dest.port, dest.host);
@@ -75,6 +78,7 @@ class MiniSip {
 
   _onMessage(buf, rinfo) {
     const text = buf.toString('utf8');
+    this.logger('debug', `SIP recv from ${rinfo.address}:${rinfo.port}\n${text}`);
     if (text.startsWith('SIP/2.0')) {
       const res = parseResponse(text);
       // match by call-id and cseq method

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -89,7 +89,7 @@ async function callOnce(cfg) {
   logger('info', `REGISTER naar ${sip_domain} als ${username}`);
   logger('info', `Start SIP socket op ${local_ip}:${local_sip_port}`);
   try {
-    await sip.start({ protocol: 'UDP', address: local_ip, port: local_sip_port });
+    await sip.start({ address: local_ip, port: local_sip_port, logger });
   } catch (err) {
     logger('error', `Kon SIP-poort niet binden op ${local_ip}:${local_sip_port}: ${err.code || err.message || err}`);
     if (err && err.code === 'EADDRINUSE') {


### PR DESCRIPTION
## Summary
- log raw SIP messages sent and received to aid troubleshooting
- allow passing a logger into MiniSip for debugging
- pass logger from call flow to MiniSip start

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b06147df1c83309dfc6ced09a89e24