### PR TITLE
Use correct Soundboard app identifier

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ class VoipPlayerApp extends Homey.App {
 
     action.registerArgumentAutocompleteListener('sound', async (query, args) => {
       try {
-        const sb = await this.homey.api.getApiApp('com.soundboard');
+        const sb = await this.homey.api.getApiApp('com.athom.soundboard');
         const sounds = await sb.get('/sounds');
         const q = (query || '').toLowerCase();
         return (sounds || [])
@@ -88,7 +88,7 @@ class VoipPlayerApp extends Homey.App {
 
   async _resolveSoundboardToWav(soundArg) {
     const path = require('path'); const fs = require('fs'); const os = require('os');
-    const sb = await this.homey.api.getApiApp('com.soundboard');
+    const sb = await this.homey.api.getApiApp('com.athom.soundboard');
     const s = await sb.get(`/sounds/${encodeURIComponent(soundArg.id)}`);
     const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
     if (s && s.url) {


### PR DESCRIPTION
## Summary
- ensure Soundboard API calls target the correct `com.athom.soundboard` app

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b067eed5948330841025dce8111e6b