### PR TITLE
fix: correct SIP digest header formatting

### DIFF
--- a/.homeybuild/lib/sip_call_play.js
+++ b/.homeybuild/lib/sip_call_play.js
@@ -29,18 +29,18 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password) {
   const cnonce = crypto.randomBytes(8).toString('hex');
   const nc = '00000001';
   const response = makeDigestResponse({ username, password, method, uri, realm: a.realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
-  return [
-    'Digest',
+  const params = [
     `username="${username}"`,
     `realm="${a.realm}"`,
     `nonce="${a.nonce}"`,
     `uri="${uri}"`,
     `response="${response}"`,
     a.qop ? `qop=${a.qop}` : '',
-    `algorithm=MD5`,
+    'algorithm=MD5',
     `cnonce="${cnonce}"`,
     `nc=${nc}`
   ].filter(Boolean).join(', ');
+  return `Digest ${params}`;
 }
 
 function buildSdpOffer(localIp, rtpPort) {

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -29,18 +29,18 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password) {
   const cnonce = crypto.randomBytes(8).toString('hex');
   const nc = '00000001';
   const response = makeDigestResponse({ username, password, method, uri, realm: a.realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
-  return [
-    'Digest',
+  const params = [
     `username="${username}"`,
     `realm="${a.realm}"`,
     `nonce="${a.nonce}"`,
     `uri="${uri}"`,
     `response="${response}"`,
     a.qop ? `qop=${a.qop}` : '',
-    `algorithm=MD5`,
+    'algorithm=MD5',
     `cnonce="${cnonce}"`,
     `nc=${nc}`
   ].filter(Boolean).join(', ');
+  return `Digest ${params}`;
 }
 
 function buildSdpOffer(localIp, rtpPort) {


### PR DESCRIPTION
## Summary
- fix SIP digest Authorization header by removing erroneous comma
- update build artifacts

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e ...` (verifies Authorization header format)


------
https://chatgpt.com/codex/tasks/task_e_68b14de898648330b8d49f7b686f5e01