### PR TITLE
feat: allow configuring SIP realm

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -53,6 +53,14 @@
       }
     },
     {
+      "id": "realm",
+      "type": "text",
+      "title": {
+        "en": "Realm (optional)",
+        "nl": "Realm (optioneel)"
+      }
+    },
+    {
       "id": "display_name",
       "type": "text",
       "title": {

--- a/.homeycompose/settings/settings.json
+++ b/.homeycompose/settings/settings.json
@@ -32,6 +32,14 @@
     }
   },
   {
+    "id": "realm",
+    "type": "text",
+    "title": {
+      "en": "Realm (optional)",
+      "nl": "Realm (optioneel)"
+    }
+  },
+  {
     "id": "display_name",
     "type": "text",
     "title": {

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 VOIP Support voor Homey.
 
-Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, wachtwoord en poorten naar wens aanpasbaar zijn.
+Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, wachtwoord, realm en poorten naar wens aanpasbaar zijn.

--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ class VoipPlayerApp extends Homey.App {
         sip_proxy: this.homey.settings.get('sip_proxy') || null,
         username: this.homey.settings.get('username'),
         password: this.homey.settings.get('password'),
+        realm: this.homey.settings.get('realm') || '',
         display_name: this.homey.settings.get('display_name') || 'HomeyBot',
         from_user: this.homey.settings.get('from_user') || this.homey.settings.get('username'),
         local_ip: this.homey.settings.get('local_ip'),

--- a/app.json
+++ b/app.json
@@ -54,6 +54,14 @@
       }
     },
     {
+      "id": "realm",
+      "type": "text",
+      "title": {
+        "en": "Realm (optional)",
+        "nl": "Realm (optioneel)"
+      }
+    },
+    {
       "id": "display_name",
       "type": "text",
       "title": {

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -24,14 +24,15 @@ function makeDigestResponse({ username, password, method, uri, realm, nonce, qop
   return qop ? md5(`${HA1}:${nonce}:${nc}:${cnonce}:${qop}:${HA2}`)
              : md5(`${HA1}:${nonce}:${HA2}`);
 }
-function buildAuthHeader(wwwAuth, { method, uri }, username, password) {
+function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOverride) {
   const a = parseAuthHeader(wwwAuth);
   const cnonce = crypto.randomBytes(8).toString('hex');
   const nc = '00000001';
-  const response = makeDigestResponse({ username, password, method, uri, realm: a.realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
+  const realm = (realmOverride !== undefined && realmOverride !== null) ? realmOverride : a.realm;
+  const response = makeDigestResponse({ username, password, method, uri, realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
   const params = [
     `username="${username}"`,
-    `realm="${a.realm}"`,
+    `realm="${realm}"`,
     `nonce="${a.nonce}"`,
     `uri="${uri}"`,
     `response="${response}"`,
@@ -77,13 +78,14 @@ function buildVia(ip, port) {
 
 async function callOnce(cfg) {
   const {
-    sip_domain, sip_proxy, username, password, display_name, from_user,
+    sip_domain, sip_proxy, username, password, realm, display_name, from_user,
     local_ip, local_sip_port, local_rtp_port, expires_sec, invite_timeout,
     to, wavPath, logger = () => {}
   } = cfg;
 
   const contactUri = `sip:${from_user}@${local_ip}:${local_sip_port}`;
   const toUri = /^\\d+$/.test(to) ? `sip:${to}@${sip_domain}` : (to.startsWith('sip:') ? to : `sip:${to}`);
+  const registerToUri = `sip:${from_user}@${sip_domain}`;
   const reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
 
   logger('info', `REGISTER naar ${sip_domain} als ${username}`);
@@ -121,6 +123,7 @@ async function callOnce(cfg) {
     // REGISTER
     await new Promise((resolve, reject) => {
       const register = baseReq('REGISTER', `sip:${sip_domain}`, {
+        to: { uri: registerToUri },
         contact: [{ uri: contactUri, params: { expires: String(expires_sec) } }],
         expires: expires_sec
       });
@@ -134,7 +137,7 @@ async function callOnce(cfg) {
         if (res.status === 401 || res.status === 407) {
           logger('info', `REGISTER challenge: ${res.status}`);
           const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
-          const auth = buildAuthHeader(hdr, { method: 'REGISTER', uri: register.uri }, username, password);
+          const auth = buildAuthHeader(hdr, { method: 'REGISTER', uri: register.uri }, username, password, realm);
           const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
           const r2 = { ...register };
           r2.headers = { ...register.headers, [hdrName]: auth, cseq: { method: 'REGISTER', seq: 2 } };
@@ -246,7 +249,7 @@ async function callOnce(cfg) {
         if (res.status === 401 || res.status === 407) {
           logger('info', `INVITE challenge: ${res.status}`);
           const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
-          const auth = buildAuthHeader(hdr, { method: 'INVITE', uri: msg.uri }, username, password);
+          const auth = buildAuthHeader(hdr, { method: 'INVITE', uri: msg.uri }, username, password, realm);
           const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
           const reinvite = { ...msg };
           reinvite.headers = { ...msg.headers, [hdrName]: auth, cseq: { method: 'INVITE', seq: ++cseq } };

--- a/settings/index.html
+++ b/settings/index.html
@@ -26,6 +26,9 @@
     <label>Password
       <input id="password" type="password" />
     </label>
+    <label>Realm (optional)
+      <input id="realm" type="text" />
+    </label>
     <label>Display name (From)
       <input id="display_name" type="text" />
     </label>
@@ -51,7 +54,7 @@
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','password','display_name','from_user','local_ip','local_sip_port','local_rtp_port','expires_sec','invite_timeout'];
+      const fields = ['sip_domain','sip_proxy','username','password','realm','display_name','from_user','local_ip','local_sip_port','local_rtp_port','expires_sec','invite_timeout'];
       fields.forEach(key => {
         Homey.get(key, (err, value) => {
           if (!err && document.getElementById(key)) {


### PR DESCRIPTION
## Summary
- allow overriding SIP digest realm via app settings
- register using user's address in To header

## Testing
- `node --check app.js`
- `node --check lib/sip_call_play.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1500704148330a92c0b747be64a8b