### PR TITLE
Fix SIP digest auth to use realm from server challenge

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -28,7 +28,7 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOver
   const a = parseAuthHeader(wwwAuth);
   const cnonce = crypto.randomBytes(8).toString('hex');
   const nc = '00000001';
-  const realm = (realmOverride !== undefined && realmOverride !== null) ? realmOverride : a.realm;
+  const realm = realmOverride || a.realm;
   const response = makeDigestResponse({ username, password, method, uri, realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
   const params = [
     `username="${username}"`,


### PR DESCRIPTION
## Summary
- use server-provided realm when computing SIP digest auth if configuration leaves it blank

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b155f3a91c8330acac436ddeece558