### PR TITLE
Fix SIP digest auth to use realm from server challenge

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -28,7 +28,7 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOver
   const a = parseAuthHeader(wwwAuth);
   const cnonce = crypto.randomBytes(8).toString('hex');
   const nc = '00000001';
-  const realm = (realmOverride !== undefined && realmOverride !== null) ? realmOverride : a.realm;
+  const realm = realmOverride || a.realm;
   const response = makeDigestResponse({ username, password, method, uri, realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
   const params = [
     `username="${username}"`,
@@ -38,8 +38,8 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOver
     `response="${response}"`,
     a.qop ? `qop=${a.qop}` : '',
     'algorithm=MD5',
-    `cnonce="${cnonce}"`,
-    `nc=${nc}`
+    a.qop ? `cnonce="${cnonce}"` : '',
+    a.qop ? `nc=${nc}` : ''
   ].filter(Boolean).join(', ');
   return `Digest ${params}`;
 }
@@ -140,7 +140,12 @@ async function callOnce(cfg) {
           const auth = buildAuthHeader(hdr, { method: 'REGISTER', uri: register.uri }, username, password, realm);
           const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
           const r2 = { ...register };
-          r2.headers = { ...register.headers, [hdrName]: auth, cseq: { method: 'REGISTER', seq: 2 } };
+          r2.headers = {
+            ...register.headers,
+            [hdrName]: auth,
+            cseq: { method: 'REGISTER', seq: 2 },
+            via: [ buildVia(local_ip, local_sip_port) ]
+          };
           logger('info', 'Send REGISTER with auth');
           sip.send(r2, res2 => {
             logger('info', `REGISTER with auth response: ${res2.status} ${res2.reason || ''}`);


### PR DESCRIPTION
## Summary
- use server-provided realm when computing SIP digest auth if configuration leaves it blank
- skip cnonce/nc when the server challenge omits qop and regenerate Via branch for authenticated REGISTER

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b155f3a91c8330acac436ddeece558