### PR TITLE
fix: use AoR in REGISTER digest

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -137,7 +137,13 @@ async function callOnce(cfg) {
         if (res.status === 401 || res.status === 407) {
           logger('info', `REGISTER challenge: ${res.status}`);
           const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
-          const auth = buildAuthHeader(hdr, { method: 'REGISTER', uri: register.uri }, username, password, realm);
+          const auth = buildAuthHeader(
+            hdr,
+            { method: 'REGISTER', uri: registerToUri },
+            username,
+            password,
+            realm
+          );
           const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
           const r2 = { ...register };
           r2.headers = {


### PR DESCRIPTION
## Summary
- derive REGISTER digest URI from the address-of-record instead of the request URI

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1601d4c68833099b8b2bf9a105516