### PR TITLE
Add configurable STUN support

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -120,6 +120,23 @@
         "nl": "Invite timeout (s)"
       },
       "value": 45
+    },
+    {
+      "id": "stun_server",
+      "type": "text",
+      "title": {
+        "en": "STUN server (optional)",
+        "nl": "STUN-server (optioneel)"
+      }
+    },
+    {
+      "id": "stun_port",
+      "type": "number",
+      "title": {
+        "en": "STUN port",
+        "nl": "STUN-poort"
+      },
+      "value": 3478
     }
   ],
   "icon": "assets/icon.svg",

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 VOIP Support voor Homey.
 
 Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, wachtwoord, realm en poorten naar wens aanpasbaar zijn.
+
+Optioneel kan een STUN-server opgegeven worden om het publieke IP-adres en poorten te bepalen. Dit kan helpen bij NAT-problemen bij inkomende SIP en RTP.

--- a/app.js
+++ b/app.js
@@ -39,7 +39,9 @@ class VoipPlayerApp extends Homey.App {
         local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
         local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
-        invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45)
+        invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
+        stun_server: this.homey.settings.get('stun_server') || '',
+        stun_port: Number(this.homey.settings.get('stun_port') || 3478)
       };
 
       for (const k of ['sip_domain','username','password','local_ip']) {

--- a/app.json
+++ b/app.json
@@ -121,6 +121,23 @@
         "nl": "Invite timeout (s)"
       },
       "value": 45
+    },
+    {
+      "id": "stun_server",
+      "type": "text",
+      "title": {
+        "en": "STUN server (optional)",
+        "nl": "STUN-server (optioneel)"
+      }
+    },
+    {
+      "id": "stun_port",
+      "type": "number",
+      "title": {
+        "en": "STUN port",
+        "nl": "STUN-poort"
+      },
+      "value": 3478
     }
   ],
   "icon": "assets/icon.svg",

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -4,6 +4,7 @@ const sip = require('./sipstack');
 const dgram = require('dgram');
 const crypto = require('crypto');
 const { readWavPcm16Mono8k, pcm16ToUlawBuffer } = require('./wav_utils');
+const stun = require('./stun_client');
 
 function genBranch() { return 'z9hG4bK-' + crypto.randomBytes(8).toString('hex'); }
 function genTag()    { return crypto.randomBytes(8).toString('hex'); }
@@ -80,10 +81,32 @@ async function callOnce(cfg) {
   const {
     sip_domain, sip_proxy, username, password, realm, display_name, from_user,
     local_ip, local_sip_port, local_rtp_port, expires_sec, invite_timeout,
+    stun_server, stun_port,
     to, wavPath, logger = () => {}
   } = cfg;
 
-  const contactUri = `sip:${from_user}@${local_ip}:${local_sip_port}`;
+  let public_ip = local_ip;
+  let public_sip_port = local_sip_port;
+  let public_rtp_port = local_rtp_port;
+  if (stun_server) {
+    try {
+      const sipMap = await stun.discover(stun_server, stun_port || 3478, local_ip, local_sip_port);
+      if (sipMap && sipMap.address) {
+        public_ip = sipMap.address;
+        public_sip_port = sipMap.port;
+      }
+      const rtpMap = await stun.discover(stun_server, stun_port || 3478, local_ip, local_rtp_port);
+      if (rtpMap && rtpMap.address) {
+        public_ip = rtpMap.address;
+        public_rtp_port = rtpMap.port;
+      }
+      logger('info', `STUN public mapping: SIP ${public_ip}:${public_sip_port}, RTP ${public_rtp_port}`);
+    } catch (e) {
+      logger('error', `STUN failed: ${e.message || e}`);
+    }
+  }
+
+  const contactUri = `sip:${from_user}@${public_ip}:${public_sip_port}`;
   const toUri = /^\\d+$/.test(to) ? `sip:${to}@${sip_domain}` : (to.startsWith('sip:') ? to : `sip:${to}`);
   const registerToUri = `sip:${from_user}@${sip_domain}`;
   const reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
@@ -111,7 +134,7 @@ async function callOnce(cfg) {
           'call-id': callId,
           cseq: { method, seq: 1 },
           contact: [{ uri: contactUri }],
-          via: [ buildVia(local_ip, local_sip_port) ],
+          via: [ buildVia(public_ip, public_sip_port) ],
           'max-forwards': 70,
           'user-agent': 'HomeySIP-POC/0.2',
           ...extraHeaders
@@ -164,7 +187,7 @@ async function callOnce(cfg) {
     });
 
     // INVITE
-    const invite = baseReq('INVITE', reqUri, { 'content-type': 'application/sdp' }, buildSdpOffer(local_ip, local_rtp_port));
+    const invite = baseReq('INVITE', reqUri, { 'content-type': 'application/sdp' }, buildSdpOffer(public_ip, public_rtp_port));
     let callId = invite.headers['call-id'];
     let cseq = invite.headers.cseq.seq;
 
@@ -196,7 +219,7 @@ async function callOnce(cfg) {
           from: invite.headers.from,
           'call-id': callId,
           cseq: { method: 'ACK', seq: ++cseq },
-          via: [ buildVia(local_ip, local_sip_port) ],
+          via: [ buildVia(public_ip, public_sip_port) ],
           contact: invite.headers.contact
         }
       };
@@ -214,7 +237,7 @@ async function callOnce(cfg) {
             from: invite.headers.from,
             'call-id': callId,
             cseq: { method: 'BYE', seq: ++cseq },
-            via: [ buildVia(local_ip, local_sip_port) ],
+            via: [ buildVia(public_ip, public_sip_port) ],
             contact: invite.headers.contact
           }
         };

--- a/lib/stun_client.js
+++ b/lib/stun_client.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const dgram = require('dgram');
+const crypto = require('crypto');
+
+async function discover(server, port = 3478, localIp, localPort, timeout = 2000) {
+  return new Promise((resolve, reject) => {
+    const socket = dgram.createSocket('udp4');
+    const tid = crypto.randomBytes(12);
+    const buf = Buffer.alloc(20);
+    buf.writeUInt16BE(0x0001, 0); // Binding request
+    buf.writeUInt16BE(0, 2); // length
+    buf.writeUInt32BE(0x2112A442, 4); // magic cookie
+    tid.copy(buf, 8);
+
+    let timer;
+    socket.on('message', msg => {
+      clearTimeout(timer);
+      try {
+        let offset = 20;
+        while (offset + 4 <= msg.length) {
+          const type = msg.readUInt16BE(offset); offset += 2;
+          const len = msg.readUInt16BE(offset); offset += 2;
+          if (type === 0x0020) { // XOR-MAPPED-ADDRESS
+            const family = msg.readUInt8(offset + 1);
+            if (family !== 0x01) break; // only IPv4
+            const xport = msg.readUInt16BE(offset + 2) ^ 0x2112;
+            const xaddr = msg.readUInt32BE(offset + 4) ^ 0x2112A442;
+            const ip = [xaddr >>> 24 & 0xff, xaddr >>> 16 & 0xff, xaddr >>> 8 & 0xff, xaddr & 0xff].join('.');
+            socket.close();
+            return resolve({ address: ip, port: xport });
+          }
+          offset += len + (len % 4 ? 4 - (len % 4) : 0);
+        }
+        socket.close();
+        reject(new Error('No XOR-MAPPED-ADDRESS in STUN response'));
+      } catch (e) {
+        socket.close();
+        reject(e);
+      }
+    });
+    socket.on('error', err => {
+      clearTimeout(timer);
+      socket.close();
+      reject(err);
+    });
+    socket.bind(localPort, localIp, () => {
+      socket.send(buf, port, server);
+    });
+    timer = setTimeout(() => {
+      socket.close();
+      reject(new Error('STUN timeout'));
+    }, timeout);
+  });
+}
+
+module.exports = { discover };

--- a/settings/index.html
+++ b/settings/index.html
@@ -50,11 +50,17 @@
     <label>Invite timeout (s)
       <input id="invite_timeout" type="number" />
     </label>
+    <label>STUN server (optional)
+      <input id="stun_server" type="text" />
+    </label>
+    <label>STUN port
+      <input id="stun_port" type="number" />
+    </label>
     <button type="submit">Save</button>
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','password','realm','display_name','from_user','local_ip','local_sip_port','local_rtp_port','expires_sec','invite_timeout'];
+      const fields = ['sip_domain','sip_proxy','username','password','realm','display_name','from_user','local_ip','local_sip_port','local_rtp_port','expires_sec','invite_timeout','stun_server','stun_port'];
       fields.forEach(key => {
         Homey.get(key, (err, value) => {
           if (!err && document.getElementById(key)) {


### PR DESCRIPTION
## Summary
- add optional STUN server/port settings
- discover public address via STUN and use in SIP headers/SDP

## Testing
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b1a80a832c833082ebf486e40dc2e1