### PR TITLE
Handle legacy STUN responses

### DIFF
--- a/lib/stun_client.js
+++ b/lib/stun_client.js
@@ -21,19 +21,26 @@ async function discover(server, port = 3478, localIp, localPort, timeout = 2000)
         while (offset + 4 <= msg.length) {
           const type = msg.readUInt16BE(offset); offset += 2;
           const len = msg.readUInt16BE(offset); offset += 2;
-          if (type === 0x0020) { // XOR-MAPPED-ADDRESS
+          if (type === 0x0020 || type === 0x0001) { // XOR-MAPPED-ADDRESS or legacy MAPPED-ADDRESS
             const family = msg.readUInt8(offset + 1);
             if (family !== 0x01) break; // only IPv4
-            const xport = msg.readUInt16BE(offset + 2) ^ 0x2112;
-            const xaddr = msg.readUInt32BE(offset + 4) ^ 0x2112A442;
-            const ip = [xaddr >>> 24 & 0xff, xaddr >>> 16 & 0xff, xaddr >>> 8 & 0xff, xaddr & 0xff].join('.');
+            let port;
+            let ip;
+            if (type === 0x0020) {
+              port = msg.readUInt16BE(offset + 2) ^ 0x2112;
+              const xaddr = msg.readUInt32BE(offset + 4) ^ 0x2112A442;
+              ip = [xaddr >>> 24 & 0xff, xaddr >>> 16 & 0xff, xaddr >>> 8 & 0xff, xaddr & 0xff].join('.');
+            } else {
+              port = msg.readUInt16BE(offset + 2);
+              ip = `${msg[offset + 4]}.${msg[offset + 5]}.${msg[offset + 6]}.${msg[offset + 7]}`;
+            }
             socket.close();
-            return resolve({ address: ip, port: xport });
+            return resolve({ address: ip, port });
           }
           offset += len + (len % 4 ? 4 - (len % 4) : 0);
         }
         socket.close();
-        reject(new Error('No XOR-MAPPED-ADDRESS in STUN response'));
+        reject(new Error('No MAPPED-ADDRESS in STUN response'));
       } catch (e) {
         socket.close();
         reject(e);


### PR DESCRIPTION
## Summary
- Support STUN servers that return legacy `MAPPED-ADDRESS` instead of `XOR-MAPPED-ADDRESS`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b1ab368d2c8330af4815f150406f04