### PR TITLE
Add logging for SIP stack errors

### DIFF
--- a/lib/sipstack.js
+++ b/lib/sipstack.js
@@ -26,6 +26,12 @@ class SipStack {
             const src = rinfo || {};
             this.logger('debug', `SIP recv from ${src.address || src.host || ''}:${src.port || ''}\n${sip.stringify(msg)}`);
           } catch (e) {}
+        },
+        error: (e) => {
+          try {
+            const err = e && e.message ? e.message : e;
+            this.logger('error', `SIP stack error: ${err}`);
+          } catch (_) {}
         }
       }
     }, rq => {


### PR DESCRIPTION
## Summary
- log SIP stack errors to help diagnose network issues

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b1b1f041e88330ba187393d87b8c4b