### PR TITLE
feat: add SIP transport option

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -86,6 +86,15 @@
       }
     },
     {
+      "id": "sip_transport",
+      "type": "text",
+      "title": {
+        "en": "SIP transport (UDP or TCP)",
+        "nl": "SIP-transport (UDP of TCP)"
+      },
+      "value": "UDP"
+    },
+    {
       "id": "local_sip_port",
       "type": "number",
       "title": {

--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ class VoipPlayerApp extends Homey.App {
         display_name: this.homey.settings.get('display_name') || 'HomeyBot',
         from_user: this.homey.settings.get('from_user') || this.homey.settings.get('username'),
         local_ip: this.homey.settings.get('local_ip'),
+        sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
         local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
         local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),

--- a/app.json
+++ b/app.json
@@ -87,6 +87,15 @@
       }
     },
     {
+      "id": "sip_transport",
+      "type": "text",
+      "title": {
+        "en": "SIP transport (UDP or TCP)",
+        "nl": "SIP-transport (UDP of TCP)"
+      },
+      "value": "UDP"
+    },
+    {
       "id": "local_sip_port",
       "type": "number",
       "title": {

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -73,8 +73,10 @@ function parseRemoteRtp(sdp) {
   if (ip && port && hasPcmu) return { ip, port };
   return null;
 }
-function buildVia(ip, port) {
-  return { version: '2.0', protocol: 'UDP', host: ip, port, params: { branch: genBranch(), rport: null } };
+function buildVia(ip, port, protocol = 'UDP') {
+  const params = { branch: genBranch() };
+  if (protocol === 'UDP') params.rport = null;
+  return { version: '2.0', protocol, host: ip, port, params };
 }
 
 async function callOnce(cfg) {
@@ -82,8 +84,12 @@ async function callOnce(cfg) {
     sip_domain, sip_proxy, username, password, realm, display_name, from_user,
     local_ip, local_sip_port, local_rtp_port, expires_sec, invite_timeout,
     stun_server, stun_port,
+    sip_transport = 'UDP',
     to, wavPath, logger = () => {}
   } = cfg;
+
+  const transport = (sip_transport || 'UDP').toUpperCase();
+  const transportParam = transport.toLowerCase();
 
   let public_ip = local_ip;
   let public_sip_port = local_sip_port;
@@ -106,15 +112,16 @@ async function callOnce(cfg) {
     }
   }
 
-  const contactUri = `sip:${from_user}@${public_ip}:${public_sip_port}`;
+  const contactUri = `sip:${from_user}@${public_ip}:${public_sip_port};transport=${transportParam}`;
   const toUri = /^\\d+$/.test(to) ? `sip:${to}@${sip_domain}` : (to.startsWith('sip:') ? to : `sip:${to}`);
   const registerToUri = `sip:${from_user}@${sip_domain}`;
-  const reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
+  let reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
+  if (!/;transport=/i.test(reqUri)) reqUri += `;transport=${transportParam}`;
 
   logger('info', `REGISTER naar ${sip_domain} als ${username}`);
   logger('info', `Start SIP socket op ${local_ip}:${local_sip_port}`);
   try {
-    await sip.start({ address: local_ip, port: local_sip_port, logger });
+    await sip.start({ address: local_ip, port: local_sip_port, logger, transport });
   } catch (err) {
     logger('error', `Kon SIP-poort niet binden op ${local_ip}:${local_sip_port}: ${err.code || err.message || err}`);
     if (err && err.code === 'EADDRINUSE') {
@@ -134,7 +141,7 @@ async function callOnce(cfg) {
           'call-id': callId,
           cseq: { method, seq: 1 },
           contact: [{ uri: contactUri }],
-          via: [ buildVia(public_ip, public_sip_port) ],
+          via: [ buildVia(public_ip, public_sip_port, transport) ],
           'max-forwards': 70,
           'user-agent': 'HomeySIP-POC/0.2',
           ...extraHeaders
@@ -145,7 +152,7 @@ async function callOnce(cfg) {
 
     // REGISTER
     await new Promise((resolve, reject) => {
-      const register = baseReq('REGISTER', `sip:${sip_domain}`, {
+      const register = baseReq('REGISTER', `sip:${sip_domain};transport=${transportParam}`, {
         to: { uri: registerToUri },
         contact: [{ uri: contactUri, params: { expires: String(expires_sec) } }],
         expires: expires_sec
@@ -173,7 +180,7 @@ async function callOnce(cfg) {
             ...register.headers,
             [hdrName]: auth,
             cseq: { method: 'REGISTER', seq: 2 },
-            via: [ buildVia(local_ip, local_sip_port) ]
+            via: [ buildVia(local_ip, local_sip_port, transport) ]
           };
           logger('info', 'Send REGISTER with auth');
           sip.send(r2, res2 => {
@@ -219,7 +226,7 @@ async function callOnce(cfg) {
           from: invite.headers.from,
           'call-id': callId,
           cseq: { method: 'ACK', seq: ++cseq },
-          via: [ buildVia(public_ip, public_sip_port) ],
+          via: [ buildVia(public_ip, public_sip_port, transport) ],
           contact: invite.headers.contact
         }
       };
@@ -237,7 +244,7 @@ async function callOnce(cfg) {
             from: invite.headers.from,
             'call-id': callId,
             cseq: { method: 'BYE', seq: ++cseq },
-            via: [ buildVia(public_ip, public_sip_port) ],
+            via: [ buildVia(public_ip, public_sip_port, transport) ],
             contact: invite.headers.contact
           }
         };

--- a/lib/sipstack.js
+++ b/lib/sipstack.js
@@ -8,12 +8,14 @@ class SipStack {
     this.requestHandlers = [];
   }
 
-  async start({ address, port, logger }) {
+  async start({ address, port, logger, transport = 'UDP' }) {
     this.logger = logger || (() => {});
     this.requestHandlers = [];
     sip.start({
       address,
       port,
+      udp: transport === 'UDP',
+      tcp: transport === 'TCP',
       logger: {
         send: (msg, rinfo) => {
           try {

--- a/settings/index.html
+++ b/settings/index.html
@@ -38,6 +38,12 @@
     <label>Local IP (Homey)
       <input id="local_ip" type="text" />
     </label>
+    <label>SIP Transport
+      <select id="sip_transport">
+        <option value="UDP">UDP</option>
+        <option value="TCP">TCP</option>
+      </select>
+    </label>
     <label>Local SIP port
       <input id="local_sip_port" type="number" />
     </label>
@@ -60,11 +66,13 @@
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','password','realm','display_name','from_user','local_ip','local_sip_port','local_rtp_port','expires_sec','invite_timeout','stun_server','stun_port'];
+      const fields = ['sip_domain','sip_proxy','username','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','expires_sec','invite_timeout','stun_server','stun_port'];
+      const defaults = { sip_transport: 'UDP' };
       fields.forEach(key => {
         Homey.get(key, (err, value) => {
           if (!err && document.getElementById(key)) {
-            document.getElementById(key).value = value !== undefined && value !== null ? value : '';
+            const v = value !== undefined && value !== null && value !== '' ? value : (defaults[key] || '');
+            document.getElementById(key).value = v;
           }
         });
       });


### PR DESCRIPTION
## Summary
- allow choosing UDP or TCP for SIP transport in settings
- pass selected transport through SIP call flow and stack initialization

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1bd00993883309066446e3e762ab6