### PR TITLE
Handle parsed authentication headers in SIP stack

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -382,4 +382,4 @@ function startRtpStream(ulaw, localIp, localPort, remote, onDone) {
   });
 }
 
-module.exports = { callOnce };
+module.exports = { callOnce, parseAuthHeader };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "engines": {
     "node": ">=16"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "sip": "^0.0.6"
   },

--- a/test/parseAuthHeader.test.js
+++ b/test/parseAuthHeader.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const { parseAuthHeader } = require('../lib/sip_call_play');
+
+test('parseAuthHeader handles string input', () => {
+  const header = 'Digest realm="sip.voipbuster.com", nonce="4000209703", algorithm=MD5';
+  assert.deepStrictEqual(
+    parseAuthHeader(header),
+    { realm: 'sip.voipbuster.com', nonce: '4000209703', algorithm: 'MD5' }
+  );
+});
+
+test('parseAuthHeader handles object input', () => {
+  const header = {
+    scheme: 'Digest',
+    realm: '"sip.voipbuster.com"',
+    nonce: '"4000209703"',
+    algorithm: 'MD5'
+  };
+  assert.deepStrictEqual(
+    parseAuthHeader(header),
+    { realm: 'sip.voipbuster.com', nonce: '4000209703', algorithm: 'MD5' }
+  );
+});
+
+test('parseAuthHeader handles array input', () => {
+  const header = [{
+    scheme: 'Digest',
+    realm: '"sip.voipbuster.com"',
+    nonce: '"4000209703"',
+    algorithm: 'MD5'
+  }];
+  assert.deepStrictEqual(
+    parseAuthHeader(header),
+    { realm: 'sip.voipbuster.com', nonce: '4000209703', algorithm: 'MD5' }
+  );
+});
+
+test('parseAuthHeader handles null', () => {
+  assert.deepStrictEqual(parseAuthHeader(null), {});
+});
+


### PR DESCRIPTION
## Summary
- robustly parse SIP authentication challenges regardless of string or object form

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1bfb903848330b78a2f4d63e2379f