### PR TITLE
Default empty realm when unset

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -51,7 +51,7 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOver
   const a = parseAuthHeader(wwwAuth);
   const cnonce = crypto.randomBytes(8).toString('hex');
   const nc = '00000001';
-  const realm = realmOverride || a.realm;
+  const realm = realmOverride || a.realm || '';
   const response = makeDigestResponse({ username, password, method, uri, realm, nonce: a.nonce, qop: a.qop, nc, cnonce });
   const params = [
     `username="${username}"`,


### PR DESCRIPTION
## Summary
- Ensure SIP auth uses an empty realm when no realm is configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1cda3682c83308d43d776c54104e0