### PR TITLE
Add optional SIP authentication ID

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -45,6 +45,14 @@
       }
     },
     {
+      "id": "auth_id",
+      "type": "text",
+      "title": {
+        "en": "Authentication ID (optional)",
+        "nl": "Authenticatie ID (optioneel)"
+      }
+    },
+    {
       "id": "password",
       "type": "password",
       "title": {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 VOIP Support voor Homey.
 
-Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, wachtwoord, realm en poorten naar wens aanpasbaar zijn.
+Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, authenticatie-ID, wachtwoord, realm en poorten naar wens aanpasbaar zijn.
 
 Optioneel kan een STUN-server opgegeven worden om het publieke IP-adres en poorten te bepalen. Dit kan helpen bij NAT-problemen bij inkomende SIP en RTP.

--- a/app.js
+++ b/app.js
@@ -31,6 +31,7 @@ class VoipPlayerApp extends Homey.App {
         sip_domain: this.homey.settings.get('sip_domain'),
         sip_proxy: this.homey.settings.get('sip_proxy') || null,
         username: this.homey.settings.get('username'),
+        auth_id: this.homey.settings.get('auth_id') || this.homey.settings.get('username'),
         password: this.homey.settings.get('password'),
         realm: this.homey.settings.get('realm') || '',
         display_name: this.homey.settings.get('display_name') || 'HomeyBot',

--- a/app.json
+++ b/app.json
@@ -46,6 +46,14 @@
       }
     },
     {
+      "id": "auth_id",
+      "type": "text",
+      "title": {
+        "en": "Authentication ID (optional)",
+        "nl": "Authenticatie ID (optioneel)"
+      }
+    },
+    {
       "id": "password",
       "type": "password",
       "title": {

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -103,7 +103,7 @@ function buildVia(ip, port, protocol = 'UDP') {
 
 async function callOnce(cfg) {
   const {
-    sip_domain, sip_proxy, username, password, realm, display_name, from_user,
+    sip_domain, sip_proxy, username, auth_id, password, realm, display_name, from_user,
     local_ip, local_sip_port, local_rtp_port, expires_sec, invite_timeout,
     stun_server, stun_port,
     sip_transport = 'UDP',
@@ -140,7 +140,8 @@ async function callOnce(cfg) {
   let reqUri = sip_proxy ? `sip:${sip_proxy.replace(/^sip:/,'')}` : toUri;
   if (!/;transport=/i.test(reqUri)) reqUri += `;transport=${transportParam}`;
 
-  logger('info', `REGISTER naar ${sip_domain} als ${username}`);
+  const authUser = auth_id || username;
+  logger('info', `REGISTER naar ${sip_domain} als ${authUser}`);
   logger('info', `Start SIP socket op ${local_ip}:${local_sip_port}`);
   try {
     await sip.start({ address: local_ip, port: local_sip_port, logger, transport });
@@ -192,7 +193,7 @@ async function callOnce(cfg) {
           const auth = buildAuthHeader(
             hdr,
             { method: 'REGISTER', uri: register.Uri },
-            username,
+            authUser,
             password,
             realm
           );
@@ -312,7 +313,7 @@ async function callOnce(cfg) {
         if (res.status === 401 || res.status === 407) {
           logger('info', `INVITE challenge: ${res.status}`);
           const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
-          const auth = buildAuthHeader(hdr, { method: 'INVITE', uri: msg.uri }, username, password, realm);
+          const auth = buildAuthHeader(hdr, { method: 'INVITE', uri: msg.uri }, authUser, password, realm);
           const hdrName = res.status === 401 ? 'authorization' : 'proxy-authorization';
           const reinvite = { ...msg };
           reinvite.headers = { ...msg.headers, [hdrName]: auth, cseq: { method: 'INVITE', seq: ++cseq } };

--- a/settings/index.html
+++ b/settings/index.html
@@ -23,6 +23,9 @@
     <label>Username
       <input id="username" type="text" />
     </label>
+    <label>Authentication ID (optional)
+      <input id="auth_id" type="text" />
+    </label>
     <label>Password
       <input id="password" type="password" />
     </label>
@@ -66,7 +69,7 @@
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','expires_sec','invite_timeout','stun_server','stun_port'];
+      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','expires_sec','invite_timeout','stun_server','stun_port'];
       const defaults = { sip_transport: 'UDP' };
       fields.forEach(key => {
         Homey.get(key, (err, value) => {


### PR DESCRIPTION
## Summary
- add optional Authentication ID setting for SIP
- support using Authentication ID when registering and authenticating calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f2b11914833091fa733f6ac9de65