### PR TITLE
Auto-append SIP domain for dialed numbers

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,8 @@ class VoipPlayerApp extends Homey.App {
         stun_port: Number(this.homey.settings.get('stun_port') || 3478)
       };
 
+      const to = number.includes('@') ? number : `${number}@${cfg.sip_domain}`;
+
       for (const k of ['sip_domain','username','password','local_ip']) {
         if (!cfg[k]) throw new Error(`Ontbrekende instelling: ${k}`);
       }
@@ -70,7 +72,7 @@ class VoipPlayerApp extends Homey.App {
       try {
         result = await callOnce({
           ...cfg,
-          to: number,
+          to,
           wavPath,
           logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
         });


### PR DESCRIPTION
## Summary
- Append configured SIP domain when the user-supplied number lacks a domain, allowing numbers to be entered without `@domain`.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f75ca74c8330b388246c94fd4a7d