### PR TITLE
Fix SDP offer to allow two-way audio negotiation

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -77,7 +77,12 @@ function buildSdpOffer(localIp, rtpPort) {
     `m=audio ${rtpPort} RTP/AVP 0`,
     'a=rtpmap:0 PCMU/8000',
     'a=ptime:20',
-    'a=sendonly'
+    // Request two-way audio by default. The RTP stream we generate is
+    // strictly one-way, but some SIP servers (e.g. 3CX) will refuse to
+    // negotiate media when the initial offer is marked as sendonly. Using
+    // sendrecv here ensures the server responds with a valid RTP address
+    // and port, after which we simply ignore any incoming audio.
+    'a=sendrecv'
   ].join('\\r\\n');
 }
 function parseRemoteRtp(sdp) {


### PR DESCRIPTION
## Summary
- send `a=sendrecv` in SDP offers so servers like 3CX return usable RTP info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fcbc3ae883308fc61d3f3cefcc19