### PR TITLE
feat: add multiple SIP codecs

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -3,7 +3,7 @@
 const sip = require('./sipstack');
 const dgram = require('dgram');
 const crypto = require('crypto');
-const { readWavPcm16Mono8k, pcm16ToUlawBuffer } = require('./wav_utils');
+const { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer } = require('./wav_utils');
 const stun = require('./stun_client');
 
 function genBranch() { return 'z9hG4bK-' + crypto.randomBytes(8).toString('hex'); }
@@ -74,8 +74,16 @@ function buildSdpOffer(localIp, rtpPort) {
     's=-',
     `c=IN IP4 ${localIp}`,
     't=0 0',
-    `m=audio ${rtpPort} RTP/AVP 0`,
+    `m=audio ${rtpPort} RTP/AVP 0 8 9 18 3 111 97 112 101`,
     'a=rtpmap:0 PCMU/8000',
+    'a=rtpmap:8 PCMA/8000',
+    'a=rtpmap:9 G722/8000',
+    'a=rtpmap:18 G729/8000',
+    'a=rtpmap:3 GSM/8000',
+    'a=rtpmap:111 iLBC/8000',
+    'a=rtpmap:97 speex/8000',
+    'a=rtpmap:112 opus/48000/2',
+    'a=rtpmap:101 telephone-event/8000',
     'a=ptime:20',
     // Request two-way audio by default. The RTP stream we generate is
     // strictly one-way, but some SIP servers (e.g. 3CX) will refuse to
@@ -88,17 +96,19 @@ function buildSdpOffer(localIp, rtpPort) {
 function parseRemoteRtp(sdp) {
   if (!sdp) return null;
   const lines = sdp.split(/\\r?\\n/);
-  let ip = null, port = null, hasPcmu = false;
+  let ip = null, port = null, pts = [];
   for (const ln of lines) {
     if (ln.startsWith('c=IN IP4')) ip = ln.split(' ')[2];
     if (ln.startsWith('m=audio')) {
       const parts = ln.split(' ');
       port = parseInt(parts[1], 10);
-      if (parts.slice(3).includes('0')) hasPcmu = true;
+      pts = parts.slice(3).map(p => parseInt(p, 10)).filter(n => !isNaN(n));
     }
   }
-  if (ip && port && hasPcmu) return { ip, port };
-  return null;
+  if (!(ip && port && pts.length)) return null;
+  const pt = pts.find(p => p === 0 || p === 8);
+  if (!pt) return null;
+  return { ip, port, pt };
 }
 function buildVia(ip, port, protocol = 'UDP') {
   const params = { branch: genBranch() };
@@ -227,7 +237,6 @@ async function callOnce(cfg) {
     let cseq = invite.headers.cseq.seq;
 
     const pcm = readWavPcm16Mono8k(wavPath);
-    const ulaw = pcm16ToUlawBuffer(pcm);
 
     let answerTs = null;
     let endReason = 'OK';
@@ -243,7 +252,15 @@ async function callOnce(cfg) {
       if (!remote) {
         endReason = 'Bad SDP';
         clearTimeout(timer);
-        return reject(new Error('Geen bruikbare SDP/rtpmap:0'));
+        return reject(new Error('Geen bruikbare SDP/codec'));
+      }
+      let encoded;
+      if (remote.pt === 0) encoded = pcm16ToUlawBuffer(pcm);
+      else if (remote.pt === 8) encoded = pcm16ToAlawBuffer(pcm);
+      else {
+        endReason = 'Unsupported codec';
+        clearTimeout(timer);
+        return reject(new Error('Geen ondersteunde codec'));
       }
       // ACK
       const ack = {
@@ -263,7 +280,7 @@ async function callOnce(cfg) {
       answerTs = Date.now();
       logger('info', `Answered. RTP -> ${remote.ip}:${remote.port}`);
 
-      startRtpStream(ulaw, local_ip, local_rtp_port, remote, () => {
+      startRtpStream(encoded, local_ip, local_rtp_port, remote, () => {
         const bye = {
           method: 'BYE',
           uri: invite.uri,
@@ -342,14 +359,14 @@ async function callOnce(cfg) {
   }
 }
 
-function startRtpStream(ulaw, localIp, localPort, remote, onDone) {
+function startRtpStream(encoded, localIp, localPort, remote, onDone) {
   const sock = dgram.createSocket('udp4');
   const SSRC = crypto.randomBytes(4).readUInt32BE(0);
   let seq = Math.floor(Math.random() * 65535);
   let ts  = Math.floor(Math.random() * 0xffffffff);
 
   const frameSize = 160; // 20ms @8kHz
-  const totalFrames = Math.ceil(ulaw.length / frameSize);
+  const totalFrames = Math.ceil(encoded.length / frameSize);
 
   sock.bind(localPort, localIp, () => {
     const t0 = process.hrtime.bigint();
@@ -357,7 +374,7 @@ function startRtpStream(ulaw, localIp, localPort, remote, onDone) {
     function buildPkt(payload) {
       const h = Buffer.alloc(12);
       h[0] = 0x80;
-      h[1] = 0x00; // PT=0 (PCMU)
+      h[1] = remote.pt & 0x7f;
       h.writeUInt16BE(seq++ & 0xffff, 2);
       h.writeUInt32BE(ts >>> 0, 4);
       h.writeUInt32BE(SSRC >>> 0, 8);
@@ -375,7 +392,7 @@ function startRtpStream(ulaw, localIp, localPort, remote, onDone) {
         sock.close(); onDone && onDone(); return;
       }
       const startIdx = i * frameSize;
-      const chunk = ulaw.slice(startIdx, Math.min(startIdx + frameSize, ulaw.length));
+      const chunk = encoded.slice(startIdx, Math.min(startIdx + frameSize, encoded.length));
       const payload = (chunk.length === frameSize) ? chunk : Buffer.concat([chunk, Buffer.alloc(frameSize - chunk.length, 0xFF)]);
       sock.send(buildPkt(payload), remote.port, remote.ip);
 

--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -51,10 +51,37 @@ function linearToUlaw(sample) {
   return ~(sign | (exponent << 4) | mantissa) & 0xFF;
 }
 
+function linearToAlaw(sample) {
+  let s = sample;
+  if (s > 32767) s = 32767;
+  if (s < -32768) s = -32768;
+  const sign = (s < 0) ? 0x80 : 0x00;
+  if (s < 0) s = -s;
+  let exponent = 7;
+  for (let exp = 7; exp > 0; exp--) {
+    if (s & (1 << (exp + 4))) { exponent = exp; break; }
+  }
+  let mantissa;
+  if (s < 16) {
+    mantissa = s << 4;
+    exponent = -1;
+  } else {
+    mantissa = (s >> (exponent + 3)) & 0x0F;
+  }
+  const alaw = (exponent << 4) | mantissa;
+  return (alaw ^ 0x55) | sign;
+}
+
 function pcm16ToUlawBuffer(pcm) {
   const out = Buffer.allocUnsafe(pcm.length);
-  for (let i=0;i<pcm.length;i++) out[i] = linearToUlaw(pcm[i]);
+  for (let i = 0; i < pcm.length; i++) out[i] = linearToUlaw(pcm[i]);
   return out;
 }
 
-module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer };
+function pcm16ToAlawBuffer(pcm) {
+  const out = Buffer.allocUnsafe(pcm.length);
+  for (let i = 0; i < pcm.length; i++) out[i] = linearToAlaw(pcm[i]);
+  return out;
+}
+
+module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer };


### PR DESCRIPTION
## Summary
- advertise additional SIP codecs in SDP offers
- detect negotiated payload and encode to PCMU or PCMA
- add A-law encoder for G.711a support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe78be9c8330a00fa71e92868cff