### PR TITLE
feat: allow codec selection and default to SIP server IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ VOIP Support voor Homey.
 Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat domein, gebruikersnaam, authenticatie-ID, wachtwoord, realm en poorten naar wens aanpasbaar zijn.
 
 Optioneel kan een STUN-server opgegeven worden om het publieke IP-adres en poorten te bepalen. Dit kan helpen bij NAT-problemen bij inkomende SIP en RTP.
+
+In de instellingen kan tevens de gewenste codec (PCMU of PCMA) worden gekozen.

--- a/app.js
+++ b/app.js
@@ -40,6 +40,7 @@ class VoipPlayerApp extends Homey.App {
         sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
         local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
         local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
+        codec: (this.homey.settings.get('codec') || 'PCMU').toUpperCase(),
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
         invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
         stun_server: this.homey.settings.get('stun_server') || '',

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -67,22 +67,17 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOver
   return `Digest ${params}`;
 }
 
-function buildSdpOffer(localIp, rtpPort) {
+function buildSdpOffer(localIp, rtpPort, codec = 'PCMU') {
+  const pt = codec === 'PCMA' ? 8 : 0;
+  const codecLine = codec === 'PCMA' ? 'a=rtpmap:8 PCMA/8000' : 'a=rtpmap:0 PCMU/8000';
   return [
     'v=0',
     `o=- 0 0 IN IP4 ${localIp}`,
     's=-',
     `c=IN IP4 ${localIp}`,
     't=0 0',
-    `m=audio ${rtpPort} RTP/AVP 0 8 9 18 3 111 97 112 101`,
-    'a=rtpmap:0 PCMU/8000',
-    'a=rtpmap:8 PCMA/8000',
-    'a=rtpmap:9 G722/8000',
-    'a=rtpmap:18 G729/8000',
-    'a=rtpmap:3 GSM/8000',
-    'a=rtpmap:111 iLBC/8000',
-    'a=rtpmap:97 speex/8000',
-    'a=rtpmap:112 opus/48000/2',
+    `m=audio ${rtpPort} RTP/AVP ${pt} 101`,
+    codecLine,
     'a=rtpmap:101 telephone-event/8000',
     'a=ptime:20',
     // Request two-way audio by default. The RTP stream we generate is
@@ -93,7 +88,7 @@ function buildSdpOffer(localIp, rtpPort) {
     'a=sendrecv'
   ].join('\\r\\n');
 }
-function parseRemoteRtp(sdp) {
+function parseRemoteRtp(sdp, fallbackIp) {
   if (!sdp) return null;
   const lines = sdp.split(/\\r?\\n/);
   let ip = null, port = null, pts = [];
@@ -105,6 +100,7 @@ function parseRemoteRtp(sdp) {
       pts = parts.slice(3).map(p => parseInt(p, 10)).filter(n => !isNaN(n));
     }
   }
+  if (!ip || ip === '0.0.0.0') ip = fallbackIp || null;
   if (!(ip && port && pts.length)) return null;
   const pt = pts.find(p => p === 0 || p === 8);
   if (!pt) return null;
@@ -119,7 +115,7 @@ function buildVia(ip, port, protocol = 'UDP') {
 async function callOnce(cfg) {
   const {
     sip_domain, sip_proxy, username, auth_id, password, realm, display_name, from_user,
-    local_ip, local_sip_port, local_rtp_port, expires_sec, invite_timeout,
+    local_ip, local_sip_port, local_rtp_port, codec = 'PCMU', expires_sec, invite_timeout,
     stun_server, stun_port,
     sip_transport = 'UDP',
     to, wavPath, logger = () => {}
@@ -232,7 +228,7 @@ async function callOnce(cfg) {
     });
 
     // INVITE
-    const invite = baseReq('INVITE', reqUri, { 'content-type': 'application/sdp' }, buildSdpOffer(public_ip, public_rtp_port));
+    const invite = baseReq('INVITE', reqUri, { 'content-type': 'application/sdp' }, buildSdpOffer(public_ip, public_rtp_port, codec));
     let callId = invite.headers['call-id'];
     let cseq = invite.headers.cseq.seq;
 
@@ -248,7 +244,8 @@ async function callOnce(cfg) {
       }, invite_timeout * 1000);
 
     const handle2xx = (res) => {
-      const remote = parseRemoteRtp(res.content);
+      const fallbackIp = (sip_proxy || sip_domain).replace(/^sip:/, '').split(':')[0];
+      const remote = parseRemoteRtp(res.content, fallbackIp);
       if (!remote) {
         endReason = 'Bad SDP';
         clearTimeout(timer);

--- a/settings/index.html
+++ b/settings/index.html
@@ -53,6 +53,12 @@
     <label>Local RTP port
       <input id="local_rtp_port" type="number" />
     </label>
+    <label>Codec
+      <select id="codec">
+        <option value="PCMU">PCMU (G711u)</option>
+        <option value="PCMA">PCMA (G711a)</option>
+      </select>
+    </label>
     <label>REGISTER Expires (s)
       <input id="expires_sec" type="number" />
     </label>
@@ -69,8 +75,8 @@
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','expires_sec','invite_timeout','stun_server','stun_port'];
-      const defaults = { sip_transport: 'UDP' };
+      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port'];
+      const defaults = { sip_transport: 'UDP', codec: 'PCMU' };
       fields.forEach(key => {
         Homey.get(key, (err, value) => {
           if (!err && document.getElementById(key)) {


### PR DESCRIPTION
## Summary
- add codec selection to settings and config
- build SDP offer with selected codec
- default remote RTP IP to SIP server when SDP omits an address

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2015c77588330a43b25bfaf330dff