### PR TITLE
Add audio format validation and conversion

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,8 +104,7 @@ class VoipPlayerApp extends Homey.App {
     } else if (s && s.data) {
       fs.writeFileSync(dest, Buffer.from(s.data, 'base64'));
     } else { throw new Error('Soundboard gaf geen url/data terug'); }
-    require('./lib/wav_utils').readWavPcm16Mono8k(dest);
-    return dest;
+    return await require('./lib/wav_utils').ensureWavPcm16Mono8k(dest);
   }
   async _ensureLocalWav(urlOrPath) {
     const fs = require('fs'); const path = require('path'); const os = require('os');
@@ -114,8 +113,7 @@ class VoipPlayerApp extends Homey.App {
       local = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
       await this._downloadToFile(urlOrPath, local);
     } else { if (!fs.existsSync(urlOrPath)) throw new Error('Bestand niet gevonden: '+urlOrPath); }
-    require('./lib/wav_utils').readWavPcm16Mono8k(local);
-    return local;
+    return await require('./lib/wav_utils').ensureWavPcm16Mono8k(local);
   }
   async _downloadToFile(url, destPath) {
     const fs = require('fs'); const http = require('http'); const https = require('https');

--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -1,5 +1,8 @@
 'use strict';
 const fs = require('fs');
+const { spawn } = require('child_process');
+const path = require('path');
+const os = require('os');
 
 function readWavPcm16Mono8k(path) {
   const buf = fs.readFileSync(path);
@@ -84,4 +87,22 @@ function pcm16ToAlawBuffer(pcm) {
   return out;
 }
 
-module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer };
+async function ensureWavPcm16Mono8k(srcPath) {
+  try {
+    readWavPcm16Mono8k(srcPath);
+    return srcPath;
+  } catch (e) {
+    let ffmpegPath = 'ffmpeg';
+    try { ffmpegPath = require('ffmpeg-static') || 'ffmpeg'; } catch {}
+    const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+    await new Promise((resolve, reject) => {
+      const proc = spawn(ffmpegPath, ['-y', '-i', srcPath, '-ac', '1', '-ar', '8000', '-sample_fmt', 's16', dest]);
+      proc.on('error', reject);
+      proc.on('close', code => code === 0 ? resolve() : reject(new Error('ffmpeg exit ' + code)));
+    });
+    readWavPcm16Mono8k(dest);
+    return dest;
+  }
+}
+
+module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer, ensureWavPcm16Mono8k };

--- a/test/wav_utils.test.js
+++ b/test/wav_utils.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+let ffmpeg = 'ffmpeg';
+try { ffmpeg = require('ffmpeg-static') || 'ffmpeg'; } catch {}
+
+const { ensureWavPcm16Mono8k, readWavPcm16Mono8k } = require('../lib/wav_utils');
+
+test('ensureWavPcm16Mono8k converts mp3 to wav', async () => {
+  const mp3 = path.join(os.tmpdir(), `tone_${Date.now()}.mp3`);
+  spawnSync(ffmpeg, ['-f', 'lavfi', '-i', 'sine=frequency=1000:duration=0.1', mp3]);
+  const out = await ensureWavPcm16Mono8k(mp3);
+  const pcm = readWavPcm16Mono8k(out);
+  assert.ok(pcm.length > 0);
+  fs.unlinkSync(mp3);
+  fs.unlinkSync(out);
+});
+
+test('ensureWavPcm16Mono8k returns original for valid wav', async () => {
+  const wav = path.join(os.tmpdir(), `tone_${Date.now()}.wav`);
+  spawnSync(ffmpeg, ['-f','lavfi','-i','sine=frequency=1000:duration=0.1','-ac','1','-ar','8000','-sample_fmt','s16', wav]);
+  const out = await ensureWavPcm16Mono8k(wav);
+  assert.strictEqual(out, wav);
+  fs.unlinkSync(wav);
+});


### PR DESCRIPTION
## Summary
- validate and convert audio files to 8k PCM WAV using ffmpeg
- ensure flow action accepts mp3 and other wav formats
- add tests for audio conversion utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2040c8b3c833096d5db0dd03b9686