### PR TITLE
Fix REGISTER auth header URI

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -201,9 +201,14 @@ async function callOnce(cfg) {
         if (res.status === 401 || res.status === 407) {
           logger('info', `REGISTER challenge: ${res.status}`);
           const hdr = res.headers['www-authenticate'] || res.headers['proxy-authenticate'];
+          // Use the request's URI when calculating the digest response.
+          // The previous code mistakenly referenced `register.Uri` (capital
+          // "U"), which is undefined. Some SIP servers tolerate the
+          // resulting `uri="undefined"` value, but others reject the
+          // authentication challenge or behave unpredictably.
           const auth = buildAuthHeader(
             hdr,
-            { method: 'REGISTER', uri: register.Uri },
+            { method: 'REGISTER', uri: register.uri },
             authUser,
             password,
             realm


### PR DESCRIPTION
## Summary
- use correct request URI when building REGISTER auth header to avoid `uri="undefined"`

## Testing
- `npm test` *(fails: ffmpeg exit 127)*

------
https://chatgpt.com/codex/tasks/task_e_68b20717d194833088ef1857cd22acac