### PR TITLE
Fix SDP line endings for correct codec negotiation

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -86,11 +86,18 @@ function buildSdpOffer(localIp, rtpPort, codec = 'PCMU') {
     // sendrecv here ensures the server responds with a valid RTP address
     // and port, after which we simply ignore any incoming audio.
     'a=sendrecv'
-  ].join('\\r\\n');
+  // RFC 4566 mandates that SDP lines are separated by CRLF. The previous
+  // implementation used the literal string "\\r\\n", which resulted in
+  // backslash characters being transmitted instead of actual newlines. This
+  // caused SIP peers to reject the offer with messages like
+  // "Geen bruikbare SDP/codec". Use real CRLF sequences instead.
+  ].join('\r\n');
 }
 function parseRemoteRtp(sdp, fallbackIp) {
   if (!sdp) return null;
-  const lines = sdp.split(/\\r?\\n/);
+  // Remote SDP may contain either CRLF or LF line endings. Parse both
+  // correctly by using a regex that matches real newline characters.
+  const lines = sdp.split(/\r?\n/);
   let ip = null, port = null, pts = [];
   for (const ln of lines) {
     if (ln.startsWith('c=IN IP4')) ip = ln.split(' ')[2];


### PR DESCRIPTION
## Summary
- Use real CRLF line endings when generating SDP offers so SIP peers parse them correctly
- Parse remote SDP using regex matching actual newline characters

## Testing
- `npm test` *(fails: spawn ffmpeg ENOENT)*
- `apt-get install -y ffmpeg` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b20a36a06c83309caf67167e6ebfc5