### PR TITLE
Add repeat playback option for SIP audio calls

### DIFF
--- a/.homeycompose/flow/actions/call_and_play.json
+++ b/.homeycompose/flow/actions/call_and_play.json
@@ -4,6 +4,7 @@
   "args": [
     { "name": "number", "type": "text", "title": { "en": "Phone number or SIP URI", "nl": "Telefoonnummer of SIP URI" } },
     { "name": "sound", "type": "autocomplete", "title": { "en": "Soundboard file (optional)", "nl": "Soundboard-bestand (optioneel)" } },
-    { "name": "file_url", "type": "text", "title": { "en": "Fallback: URL or path to WAV (8kHz mono)", "nl": "Fallback: URL of pad naar WAV (8kHz mono)" } }
+    { "name": "file_url", "type": "text", "title": { "en": "Fallback: URL or path to WAV (8kHz mono)", "nl": "Fallback: URL of pad naar WAV (8kHz mono)" } },
+    { "name": "repeat", "type": "number", "title": { "en": "Times to play audio", "nl": "Aantal keer afspelen" } }
   ]
 }

--- a/app.js
+++ b/app.js
@@ -62,21 +62,24 @@ class VoipPlayerApp extends Homey.App {
           if (!args.file_url) throw new Error('Soundboard mislukt en geen URL/pad opgegeven');
         }
       }
-      if (!wavPath) {
-        const fileUrl = String(args.file_url || '').trim();
-        if (!fileUrl) throw new Error('Geen geluidsbron opgegeven');
-        wavPath = await this._ensureLocalWav(fileUrl);
-      }
+        if (!wavPath) {
+          const fileUrl = String(args.file_url || '').trim();
+          if (!fileUrl) throw new Error('Geen geluidsbron opgegeven');
+          wavPath = await this._ensureLocalWav(fileUrl);
+        }
 
-      const { callOnce } = require('./lib/sip_call_play');
-      let result;
-      try {
-        result = await callOnce({
-          ...cfg,
-          to,
-          wavPath,
-          logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
-        });
+        const repeat = Math.max(1, Number(args.repeat || 1));
+
+        const { callOnce } = require('./lib/sip_call_play');
+        let result;
+        try {
+          result = await callOnce({
+            ...cfg,
+            to,
+            wavPath,
+            repeat,
+            logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
+          });
       } catch (e) {
         await this._triggerCompleted.trigger({
           status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'

--- a/app.json
+++ b/app.json
@@ -245,6 +245,14 @@
               "en": "Fallback: URL or path to WAV (8kHz mono)",
               "nl": "Fallback: URL of pad naar WAV (8kHz mono)"
             }
+          },
+          {
+            "name": "repeat",
+            "type": "number",
+            "title": {
+              "en": "Times to play audio",
+              "nl": "Aantal keer afspelen"
+            }
           }
         ],
         "id": "call_and_play"

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -125,8 +125,10 @@ async function callOnce(cfg) {
     local_ip, local_sip_port, local_rtp_port, codec = 'PCMU', expires_sec, invite_timeout,
     stun_server, stun_port,
     sip_transport = 'UDP',
-    to, wavPath, logger = () => {}
+    to, wavPath, repeat: repeatRaw = 1, logger = () => {}
   } = cfg;
+
+  const repeat = Math.max(1, parseInt(repeatRaw, 10) || 1);
 
   const transport = (sip_transport || 'UDP').toUpperCase();
   const transportParam = transport.toLowerCase();
@@ -289,7 +291,7 @@ async function callOnce(cfg) {
       answerTs = Date.now();
       logger('info', `Answered. RTP -> ${remote.ip}:${remote.port}`);
 
-      startRtpStream(encoded, local_ip, local_rtp_port, remote, () => {
+      startRtpStream(encoded, local_ip, local_rtp_port, remote, repeat, () => {
         const bye = {
           method: 'BYE',
           uri: invite.uri,
@@ -368,14 +370,15 @@ async function callOnce(cfg) {
   }
 }
 
-function startRtpStream(encoded, localIp, localPort, remote, onDone) {
+function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
   const sock = dgram.createSocket('udp4');
   const SSRC = crypto.randomBytes(4).readUInt32BE(0);
   let seq = Math.floor(Math.random() * 65535);
   let ts  = Math.floor(Math.random() * 0xffffffff);
 
   const frameSize = 160; // 20ms @8kHz
-  const totalFrames = Math.ceil(encoded.length / frameSize);
+  const fullBuffer = Buffer.concat(Array(Math.max(1, repeats)).fill(encoded));
+  const totalFrames = Math.ceil(fullBuffer.length / frameSize);
 
   sock.bind(localPort, localIp, () => {
     const t0 = process.hrtime.bigint();
@@ -401,7 +404,7 @@ function startRtpStream(encoded, localIp, localPort, remote, onDone) {
         sock.close(); onDone && onDone(); return;
       }
       const startIdx = i * frameSize;
-      const chunk = encoded.slice(startIdx, Math.min(startIdx + frameSize, encoded.length));
+      const chunk = fullBuffer.slice(startIdx, Math.min(startIdx + frameSize, fullBuffer.length));
       const payload = (chunk.length === frameSize) ? chunk : Buffer.concat([chunk, Buffer.alloc(frameSize - chunk.length, 0xFF)]);
       sock.send(buildPkt(payload), remote.port, remote.ip);
 


### PR DESCRIPTION
## Summary
- allow specifying how many times to play audio when placing a call
- repeat RTP stream the chosen number of times and hang up afterwards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20c83750483308a2bda9861f042d8