### PR TITLE
Include repeat placeholder in call_and_play action

### DIFF
--- a/.homeycompose/flow/actions/call_and_play.json
+++ b/.homeycompose/flow/actions/call_and_play.json
@@ -1,6 +1,6 @@
 {
   "title": { "en": "Call number and play Soundboard/URL audio", "nl": "Bel nummer en speel Soundboard/URL-geluid" },
-  "titleFormatted": { "en": "Call [[number]] and play [[sound]] / [[file_url]]", "nl": "Bel [[number]] en speel [[sound]] / [[file_url]]" },
+  "titleFormatted": { "en": "Call [[number]] and play [[sound]] / [[file_url]] [[repeat]] times", "nl": "Bel [[number]] en speel [[sound]] / [[file_url]] [[repeat]] keer" },
   "args": [
     { "name": "number", "type": "text", "title": { "en": "Phone number or SIP URI", "nl": "Telefoonnummer of SIP URI" } },
     { "name": "sound", "type": "autocomplete", "title": { "en": "Soundboard file (optional)", "nl": "Soundboard-bestand (optioneel)" } },

--- a/app.json
+++ b/app.json
@@ -219,8 +219,8 @@
           "nl": "Bel nummer en speel Soundboard/URL-geluid"
         },
         "titleFormatted": {
-          "en": "Call [[number]] and play [[sound]] / [[file_url]]",
-          "nl": "Bel [[number]] en speel [[sound]] / [[file_url]]"
+          "en": "Call [[number]] and play [[sound]] / [[file_url]] [[repeat]] times",
+          "nl": "Bel [[number]] en speel [[sound]] / [[file_url]] [[repeat]] keer"
         },
         "args": [
           {


### PR DESCRIPTION
## Summary
- add missing `[[repeat]]` token to `call_and_play` action titles so validation succeeds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b20f6be23c833092d891cfe18ec4ae