### PR TITLE
feat: add js mp3 decoder

### DIFF
--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -4,6 +4,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const os = require('os');
 const ffmpegPath = require('./ffmpeg-path');
+const { MPEGDecoder } = require('mpg123-decoder');
 
 function readWavPcm16Mono8k(path) {
   const buf = fs.readFileSync(path);
@@ -93,6 +94,14 @@ async function ensureWavPcm16Mono8k(srcPath) {
     readWavPcm16Mono8k(srcPath);
     return srcPath;
   } catch (e) {
+    const ext = path.extname(srcPath).toLowerCase();
+    if (ext === '.mp3') {
+      const pcm = await decodeMp3ToPcm16Mono8k(srcPath);
+      const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+      writeWavPcm16Mono8k(dest, pcm);
+      readWavPcm16Mono8k(dest);
+      return dest;
+    }
     const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
     await new Promise((resolve, reject) => {
       const proc = spawn(ffmpegPath, ['-y', '-i', srcPath, '-ac', '1', '-ar', '8000', '-sample_fmt', 's16', dest]);
@@ -102,6 +111,75 @@ async function ensureWavPcm16Mono8k(srcPath) {
     readWavPcm16Mono8k(dest);
     return dest;
   }
+}
+
+async function decodeMp3ToPcm16Mono8k(mp3Path) {
+  const decoder = new MPEGDecoder();
+  await decoder.ready;
+  const mp3 = fs.readFileSync(mp3Path);
+  const { channelData, sampleRate } = decoder.decode(mp3);
+  const mono = mergeChannels(channelData);
+  const resampled = resampleFloat32(mono, sampleRate, 8000);
+  return floatToInt16(resampled);
+}
+
+function mergeChannels(channels) {
+  if (channels.length === 1) return channels[0];
+  const length = channels[0].length;
+  const out = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    let sum = 0;
+    for (const ch of channels) sum += ch[i];
+    out[i] = sum / channels.length;
+  }
+  return out;
+}
+
+function resampleFloat32(data, inRate, outRate) {
+  if (inRate === outRate) return data;
+  const ratio = inRate / outRate;
+  const newLen = Math.floor(data.length / ratio);
+  const out = new Float32Array(newLen);
+  for (let i = 0; i < newLen; i++) {
+    const pos = i * ratio;
+    const i0 = Math.floor(pos);
+    const i1 = Math.min(i0 + 1, data.length - 1);
+    const frac = pos - i0;
+    out[i] = data[i0] * (1 - frac) + data[i1] * frac;
+  }
+  return out;
+}
+
+function floatToInt16(data) {
+  const out = new Int16Array(data.length);
+  for (let i = 0; i < data.length; i++) {
+    let s = data[i];
+    if (s > 1) s = 1;
+    if (s < -1) s = -1;
+    out[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+  }
+  return out;
+}
+
+function writeWavPcm16Mono8k(dest, pcm) {
+  const header = Buffer.alloc(44);
+  const dataSize = pcm.length * 2;
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + dataSize, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(8000, 24);
+  header.writeUInt32LE(8000 * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(dataSize, 40);
+  const pcmBuf = Buffer.alloc(dataSize);
+  for (let i = 0; i < pcm.length; i++) pcmBuf.writeInt16LE(pcm[i], i * 2);
+  fs.writeFileSync(dest, Buffer.concat([header, pcmBuf]));
 }
 
 module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer, ensureWavPcm16Mono8k };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,27 @@
       "name": "com.marco.voipplayer",
       "version": "0.1.1",
       "dependencies": {
+        "mpg123-decoder": "^1.0.2",
         "sip": "^0.0.6"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@eshaz/web-worker": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eshaz/web-worker/-/web-worker-1.2.2.tgz",
+      "integrity": "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@wasm-audio-decoders/common": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/common/-/common-9.0.7.tgz",
+      "integrity": "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==",
+      "license": "MIT",
+      "dependencies": {
+        "@eshaz/web-worker": "1.2.2",
+        "simple-yenc": "^1.0.4"
       }
     },
     "node_modules/async-limiter": {
@@ -19,6 +36,29 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/mpg123-decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mpg123-decoder/-/mpg123-decoder-1.0.2.tgz",
+      "integrity": "sha512-cw0Laz57gumQsfCqnNeGtgq64EcyrK/z4qx+kq4iba7iSSXfI7uO3jiHjdHxNp4PB2v08VZYZ2Fr68VM1JkaPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "9.0.7"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
+    "node_modules/simple-yenc": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-1.0.4.tgz",
+      "integrity": "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
     },
     "node_modules/sip": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "mpg123-decoder": "^1.0.2",
     "sip": "^0.0.6"
   },
   "homey": {


### PR DESCRIPTION
## Summary
- use WebAssembly mpg123-decoder to handle MP3 audio without ffmpeg
- convert decoded audio to 8kHz mono WAV for SIP playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2166a609483308935b57c990ad5bf