### PR TITLE
Use dynamic import for mpg123-decoder

### DIFF
--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -4,7 +4,11 @@ const { spawn } = require('child_process');
 const path = require('path');
 const os = require('os');
 const ffmpegPath = require('./ffmpeg-path');
-const { MPEGDecoder } = require('mpg123-decoder');
+
+// `mpg123-decoder` is an ES module. In a CommonJS environment we
+// need to use a dynamic import to load it. This avoids `require()`
+// errors when decoding MP3 files.
+let MPEGDecoder;
 
 function readWavPcm16Mono8k(path) {
   const buf = fs.readFileSync(path);
@@ -114,6 +118,9 @@ async function ensureWavPcm16Mono8k(srcPath) {
 }
 
 async function decodeMp3ToPcm16Mono8k(mp3Path) {
+  if (!MPEGDecoder) {
+    ({ MPEGDecoder } = await import('mpg123-decoder'));
+  }
   const decoder = new MPEGDecoder();
   await decoder.ready;
   const mp3 = fs.readFileSync(mp3Path);


### PR DESCRIPTION
## Summary
- fix wav_utils to import mpg123-decoder dynamically to avoid CommonJS require errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2995bd748833088cea6e4aefad46d