### PR TITLE
Remove ffmpeg usage in favor of mpg123-decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Optioneel kan een STUN-server opgegeven worden om het publieke IP-adres en poort
 
 In de instellingen kan tevens de gewenste codec (PCMU of PCMA) worden gekozen.
 
-Deze app gebruikt [`ffmpeg`](https://ffmpeg.org/) om geluidsbestanden naar het juiste formaat te converteren. Wanneer `ffmpeg` niet op het systeem aanwezig is, probeert de app automatisch het pad van de npm-module [`ffmpeg-static`](https://www.npmjs.com/package/ffmpeg-static) te gebruiken.
+Deze app gebruikt [`mpg123-decoder`](https://www.npmjs.com/package/mpg123-decoder) om MP3-bestanden naar het juiste WAV-formaat te converteren.

--- a/lib/ffmpeg-path.js
+++ b/lib/ffmpeg-path.js
@@ -1,8 +1,0 @@
-'use strict';
-let ffmpegPath;
-try {
-  ffmpegPath = require('ffmpeg-static');
-} catch (e) {
-  ffmpegPath = 'ffmpeg';
-}
-module.exports = ffmpegPath;

--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -1,9 +1,7 @@
 'use strict';
 const fs = require('fs');
-const { spawn } = require('child_process');
 const path = require('path');
 const os = require('os');
-const ffmpegPath = require('./ffmpeg-path');
 
 // `mpg123-decoder` is an ES module. In a CommonJS environment we
 // need to use a dynamic import to load it. This avoids `require()`
@@ -106,14 +104,7 @@ async function ensureWavPcm16Mono8k(srcPath) {
       readWavPcm16Mono8k(dest);
       return dest;
     }
-    const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
-    await new Promise((resolve, reject) => {
-      const proc = spawn(ffmpegPath, ['-y', '-i', srcPath, '-ac', '1', '-ar', '8000', '-sample_fmt', 's16', dest]);
-      proc.on('error', reject);
-      proc.on('close', code => code === 0 ? resolve() : reject(new Error('ffmpeg exit ' + code)));
-    });
-    readWavPcm16Mono8k(dest);
-    return dest;
+    throw e;
   }
 }
 
@@ -189,4 +180,4 @@ function writeWavPcm16Mono8k(dest, pcm) {
   fs.writeFileSync(dest, Buffer.concat([header, pcmBuf]));
 }
 
-module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer, ensureWavPcm16Mono8k };
+module.exports = { readWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer, ensureWavPcm16Mono8k, writeWavPcm16Mono8k };

--- a/test/wav_utils.test.js
+++ b/test/wav_utils.test.js
@@ -3,25 +3,24 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
-const ffmpeg = require('../lib/ffmpeg-path');
-const hasFfmpeg = spawnSync(ffmpeg, ['-version']).status === 0;
+const { ensureWavPcm16Mono8k, readWavPcm16Mono8k, writeWavPcm16Mono8k } = require('../lib/wav_utils');
 
-const { ensureWavPcm16Mono8k, readWavPcm16Mono8k } = require('../lib/wav_utils');
+const TONE_MP3_BASE64 = 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjYwLjE2LjEwMAAAAAAAAAAAAAAA//tAwAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAAFAAAEygBRUVFRUVFRUVFRUVFRUVFRUVFRfX19fX19fX19fX19fX19fX19fX2oqKioqKioqKioqKioqKioqKioqNTU1NTU1NTU1NTU1NTU1NTU1NTU//////////////////////////8AAAAATGF2YzYwLjMxAAAAAAAAAAAAAAAAJAMGAAAAAAAABMouNstvAAAAAAD/+1DEAAAKZFMyNZeAAWiVZsM5EAAfi5ZcsuWXLLloPrrctQMuI2oJLNeE6bTvtOmM2TwcWTRgLYPQQguB0KBkfv1er1ezv496Uo8iAgcg+D78QbuX6QxwG/SCGoBn9IIcBn9IY5f3dIJBhhEMb3+zFpEMWFHRgNAeYDJ58aQGLyAYfr5ICD5r0MTgkBHA4VcAAh+wZa/DIw5IskVr/kOHOGWJkiv/kBMiLEWMS7/+XTIvF5FEx/g0FQVER7/WCoiPBpWAABx1Vr+/uIAoCkwG//tSxAaAClQtFT3sAAFnCWFVn+kKARTBUBHMDoBMwKAbzDGF5MiQjMyLOrTigR4MVsIMwkgOzA6BTMCQAgCKBZlTRteO0Ua+min9en/q/+/6Pf39C9PblOnpdgAAP1hkh0PIEwRjMXN1w9/jAWAHcwLsEyMLSXmTd4A44wXYC/P3GNcTGgyyUJSmsPc1r//ev7/6t6U8U9DoXaKRm1PeKp9qLPRuQ4n742Z/f3Nd4rG2/09NCv/eioKM0LBpQwSMzKI4bgwHYBXMEFA1DD5kI07/+1LEDgAMMFMIDX4ogS+FonGv6UCO4J4MIMAzAtwCIMApQEAdgL8E0H6kCrs+p0FVmy8/UPZ3zhJv0Mex4ubX3okLdM2OQOb0xRVykU2jdhpLm2xeuzu4z6IgAAASO109/elElZ0CiAGXOAR4Iuk/4whYDINZ0ABxYIkE2YREAxNBOvCC7g5tmilafNcz6r60q+hrrvYkqpC3dCkt7+Zbpe/7df9FcAAACABe6/RVADEQMQAwXDSwAFYiaIPHczZheBswb5oEBmDEAMxw5SZ8P/7UsQVAgsQLQ0t/2oBUAWipr2QALGPiZgYSXAXPGFtzcQn0Ujb5aqYo1RrXp3da6/uum7vp990x0CyVIfUTVV/Qz7wGDtqu8/jdg4BcwBQLzBDAjAICpgWAIGDsJwY0wrRivXMHuYbWYQgsRh2A/GEADoNAoDhxxHFtGoK2vpo1cbXM6948//p1/fXfdqru7v8Uq602L6FDTgKHb8nzHgsFokEAA/yyhgQE4LOfMBOAcSGw18MuiZaVw8ae2I0KlgUaZAAPzC4MniAsVDMMFg2//tSxByAEaTxV7m5ABDehuHPmJAAOCyBKI6hBZ3QYLKAGHImXxziiRUivxcIYDE5haADcBDhzhzjEu/kQGbHPImMwQQmUkkqv5OEHJ83JxBBJEul0yLxFv++tN0EGRRMREFRvy4fBAB3AAKSXNEoShKMnmSSTUMEQOlmAyfEECJ8BQAgS5ZE1waBrZwV5Y8r9T1f/EXKnV4NWf///okqjylMQU1FMy4xMDBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVU=';
 
-test('ensureWavPcm16Mono8k converts mp3 to wav', { skip: !hasFfmpeg }, async () => {
+test('ensureWavPcm16Mono8k converts mp3 to wav', async () => {
   const mp3 = path.join(os.tmpdir(), `tone_${Date.now()}.mp3`);
-  spawnSync(ffmpeg, ['-f', 'lavfi', '-i', 'sine=frequency=1000:duration=0.1', mp3]);
+  fs.writeFileSync(mp3, Buffer.from(TONE_MP3_BASE64, 'base64'));
   const out = await ensureWavPcm16Mono8k(mp3);
   const pcm = readWavPcm16Mono8k(out);
   assert.ok(pcm.length > 0);
-  fs.unlinkSync(mp3);
   fs.unlinkSync(out);
+  fs.unlinkSync(mp3);
 });
 
-test('ensureWavPcm16Mono8k returns original for valid wav', { skip: !hasFfmpeg }, async () => {
+test('ensureWavPcm16Mono8k returns original for valid wav', async () => {
   const wav = path.join(os.tmpdir(), `tone_${Date.now()}.wav`);
-  spawnSync(ffmpeg, ['-f','lavfi','-i','sine=frequency=1000:duration=0.1','-ac','1','-ar','8000','-sample_fmt','s16', wav]);
+  const samples = new Int16Array(800);
+  writeWavPcm16Mono8k(wav, samples);
   const out = await ensureWavPcm16Mono8k(wav);
   assert.strictEqual(out, wav);
   fs.unlinkSync(wav);


### PR DESCRIPTION
## Summary
- drop ffmpeg helper and conversions
- decode MP3 with mpg123-decoder and expose WAV writer
- update tests and docs to reflect mpg123-decoder usage
- generate MP3 test fixture at runtime to avoid committing binary files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29dbe10bc83309210032f72ca6278