### PR TITLE
Handle MP3 files without relying on extension

### DIFF
--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -96,13 +96,20 @@ async function ensureWavPcm16Mono8k(srcPath) {
     readWavPcm16Mono8k(srcPath);
     return srcPath;
   } catch (e) {
-    const ext = path.extname(srcPath).toLowerCase();
-    if (ext === '.mp3') {
-      const pcm = await decodeMp3ToPcm16Mono8k(srcPath);
-      const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
-      writeWavPcm16Mono8k(dest, pcm);
-      readWavPcm16Mono8k(dest);
-      return dest;
+    // When the source isn't a valid WAV file, attempt to treat it as an MP3
+    // regardless of the file extension. This covers scenarios where MP3
+    // content is stored with a `.wav` extension (e.g. files downloaded from
+    // external sources or Homey soundboard entries).
+    if (e.message && e.message.includes('Geen geldige WAV')) {
+      try {
+        const pcm = await decodeMp3ToPcm16Mono8k(srcPath);
+        const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+        writeWavPcm16Mono8k(dest, pcm);
+        readWavPcm16Mono8k(dest); // throws if conversion failed
+        return dest;
+      } catch (_) {
+        // fall through and rethrow original error if MP3 decoding fails
+      }
     }
     throw e;
   }

--- a/test/wav_utils.test.js
+++ b/test/wav_utils.test.js
@@ -17,6 +17,16 @@ test('ensureWavPcm16Mono8k converts mp3 to wav', async () => {
   fs.unlinkSync(mp3);
 });
 
+test('ensureWavPcm16Mono8k handles mp3 with wav extension', async () => {
+  const fakeWav = path.join(os.tmpdir(), `tone_${Date.now()}.wav`);
+  fs.writeFileSync(fakeWav, Buffer.from(TONE_MP3_BASE64, 'base64'));
+  const out = await ensureWavPcm16Mono8k(fakeWav);
+  const pcm = readWavPcm16Mono8k(out);
+  assert.ok(pcm.length > 0);
+  fs.unlinkSync(out);
+  fs.unlinkSync(fakeWav);
+});
+
 test('ensureWavPcm16Mono8k returns original for valid wav', async () => {
   const wav = path.join(os.tmpdir(), `tone_${Date.now()}.wav`);
   const samples = new Int16Array(800);


### PR DESCRIPTION
## Summary
- Try decoding non-WAV inputs as MP3 even when the file extension is misleading
- Test MP3 handling when saved with a .wav extension

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a36304508330a082e1e62c0d9178