### PR TITLE
Stop SIP after audio playback

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -303,9 +303,12 @@ async function callOnce(cfg) {
             via: [ buildVia(public_ip, public_sip_port, transport) ],
             contact: invite.headers.contact
           }
-        };
+        }; 
         logger('info', 'Send BYE');
         sip.send(bye);
+        // Immediately stop the SIP stack so the connection closes as soon as
+        // the audio playback has finished.
+        try { sip.stop(); } catch (e) {}
         clearTimeout(timer);
         resolve({
           status: 'answered',


### PR DESCRIPTION
## Summary
- stop SIP stack as soon as audio playback ends so call disconnects immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a494d2288330bd1690b4ce11a652