### PR TITLE
Fix SIP call termination by targeting remote contact

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -273,10 +273,12 @@ async function callOnce(cfg) {
         clearTimeout(timer);
         return reject(new Error('Geen ondersteunde codec'));
       }
+      const contactHeader = Array.isArray(res.headers.contact) ? res.headers.contact[0] : res.headers.contact;
+      const remoteTarget = contactHeader && (contactHeader.uri || contactHeader);
       // ACK
       const ack = {
         method: 'ACK',
-        uri: invite.uri,
+        uri: remoteTarget || invite.uri,
         headers: {
           to: res.headers.to,
           from: invite.headers.from,
@@ -294,7 +296,7 @@ async function callOnce(cfg) {
       startRtpStream(encoded, local_ip, local_rtp_port, remote, repeat, () => {
         const bye = {
           method: 'BYE',
-          uri: invite.uri,
+          uri: remoteTarget || invite.uri,
           headers: {
             to: res.headers.to,
             from: invite.headers.from,


### PR DESCRIPTION
## Summary
- Send ACK and BYE requests to the remote Contact address returned in the 200 OK response
- Ensure SIP stack stops after playback so call closes promptly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2a64a5eb8833098e7f3e1ad2903eb