### PR TITLE
Delay SIP stack shutdown to avoid BYE send failure

### DIFF
--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -305,18 +305,19 @@ async function callOnce(cfg) {
             via: [ buildVia(public_ip, public_sip_port, transport) ],
             contact: invite.headers.contact
           }
-        }; 
+        };
         logger('info', 'Send BYE');
-        sip.send(bye);
-        // Immediately stop the SIP stack so the connection closes as soon as
-        // the audio playback has finished.
-        try { sip.stop(); } catch (e) {}
-        clearTimeout(timer);
-        resolve({
-          status: 'answered',
-          durationMs: answerTs ? (Date.now() - answerTs) : 0,
-          reason: endReason
-        });
+        try { sip.send(bye); } catch (_) {}
+        // Give the stack a moment to transmit the BYE before closing the socket.
+        setTimeout(() => {
+          try { sip.stop(); } catch (e) {}
+          clearTimeout(timer);
+          resolve({
+            status: 'answered',
+            durationMs: answerTs ? (Date.now() - answerTs) : 0,
+            reason: endReason
+          });
+        }, 100);
       });
 
       sip.recv(req => {


### PR DESCRIPTION
## Summary
- delay SIP stack shutdown until after BYE is transmitted to prevent ERR_SOCKET_DGRAM_NOT_RUNNING

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a75167d8833099fa32356387b170