### PR TITLE
feat: add hangup delay option

### DIFF
--- a/.homeycompose/flow/actions/call_and_play.json
+++ b/.homeycompose/flow/actions/call_and_play.json
@@ -1,10 +1,14 @@
 {
   "title": { "en": "Call number and play Soundboard/URL audio", "nl": "Bel nummer en speel Soundboard/URL-geluid" },
-  "titleFormatted": { "en": "Call [[number]] and play [[sound]] / [[file_url]] [[repeat]] times", "nl": "Bel [[number]] en speel [[sound]] / [[file_url]] [[repeat]] keer" },
+  "titleFormatted": {
+    "en": "Call [[number]] and play [[sound]] / [[file_url]] [[repeat]] times, wait [[delay]]s before hangup",
+    "nl": "Bel [[number]] en speel [[sound]] / [[file_url]] [[repeat]] keer, wacht [[delay]]s voor ophangen"
+  },
   "args": [
     { "name": "number", "type": "text", "title": { "en": "Phone number or SIP URI", "nl": "Telefoonnummer of SIP URI" } },
     { "name": "sound", "type": "autocomplete", "title": { "en": "Soundboard file (optional)", "nl": "Soundboard-bestand (optioneel)" } },
     { "name": "file_url", "type": "text", "title": { "en": "Fallback: URL or path to WAV (8kHz mono)", "nl": "Fallback: URL of pad naar WAV (8kHz mono)" } },
-    { "name": "repeat", "type": "number", "title": { "en": "Times to play audio", "nl": "Aantal keer afspelen" } }
+    { "name": "repeat", "type": "number", "title": { "en": "Times to play audio", "nl": "Aantal keer afspelen" } },
+    { "name": "delay", "type": "number", "title": { "en": "Delay before hangup (s)", "nl": "Vertraging voor ophangen (s)" } }
   ]
 }

--- a/app.js
+++ b/app.js
@@ -69,6 +69,7 @@ class VoipPlayerApp extends Homey.App {
         }
 
         const repeat = Math.max(1, Number(args.repeat || 1));
+        const delay = Math.max(0, Number(args.delay || 2));
 
         const { callOnce } = require('./lib/sip_call_play');
         let result;
@@ -78,6 +79,7 @@ class VoipPlayerApp extends Homey.App {
             to,
             wavPath,
             repeat,
+            delay,
             logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
           });
       } catch (e) {

--- a/app.json
+++ b/app.json
@@ -219,8 +219,8 @@
           "nl": "Bel nummer en speel Soundboard/URL-geluid"
         },
         "titleFormatted": {
-          "en": "Call [[number]] and play [[sound]] / [[file_url]] [[repeat]] times",
-          "nl": "Bel [[number]] en speel [[sound]] / [[file_url]] [[repeat]] keer"
+          "en": "Call [[number]] and play [[sound]] / [[file_url]] [[repeat]] times, wait [[delay]]s before hangup",
+          "nl": "Bel [[number]] en speel [[sound]] / [[file_url]] [[repeat]] keer, wacht [[delay]]s voor ophangen"
         },
         "args": [
           {
@@ -253,6 +253,14 @@
             "title": {
               "en": "Times to play audio",
               "nl": "Aantal keer afspelen"
+            }
+          },
+          {
+            "name": "delay",
+            "type": "number",
+            "title": {
+              "en": "Delay before hangup (s)",
+              "nl": "Vertraging voor ophangen (s)"
             }
           }
         ],

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -125,10 +125,11 @@ async function callOnce(cfg) {
     local_ip, local_sip_port, local_rtp_port, codec = 'PCMU', expires_sec, invite_timeout,
     stun_server, stun_port,
     sip_transport = 'UDP',
-    to, wavPath, repeat: repeatRaw = 1, logger = () => {}
+    to, wavPath, repeat: repeatRaw = 1, delay: delaySec = 2, logger = () => {}
   } = cfg;
 
   const repeat = Math.max(1, parseInt(repeatRaw, 10) || 1);
+  const hangupDelay = Math.max(0, Number(delaySec) || 0);
 
   const transport = (sip_transport || 'UDP').toUpperCase();
   const transportParam = transport.toLowerCase();
@@ -306,18 +307,26 @@ async function callOnce(cfg) {
             contact: invite.headers.contact
           }
         };
-        logger('info', 'Send BYE');
-        try { sip.send(bye); } catch (_) {}
-        // Give the stack a moment to transmit the BYE before closing the socket.
-        setTimeout(() => {
-          try { sip.stop(); } catch (e) {}
-          clearTimeout(timer);
-          resolve({
-            status: 'answered',
-            durationMs: answerTs ? (Date.now() - answerTs) : 0,
-            reason: endReason
-          });
-        }, 100);
+        const sendBye = () => {
+          logger('info', 'Send BYE');
+          try { sip.send(bye); } catch (_) {}
+          // Give the stack a moment to transmit the BYE before closing the socket.
+          setTimeout(() => {
+            try { sip.stop(); } catch (e) {}
+            clearTimeout(timer);
+            resolve({
+              status: 'answered',
+              durationMs: answerTs ? (Date.now() - answerTs) : 0,
+              reason: endReason
+            });
+          }, 100);
+        };
+        if (hangupDelay > 0) {
+          logger('info', `Waiting ${hangupDelay}s before hangup`);
+          setTimeout(sendBye, hangupDelay * 1000);
+        } else {
+          sendBye();
+        }
       });
 
       sip.recv(req => {


### PR DESCRIPTION
## Summary
- allow setting a delay before hanging up after audio playback (default 2s)
- expose delay option on flow card

## Testing
- `npm test` *(fails: Cannot find module './ffmpeg-path')*
- `node --test test/*.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2a8e338788330a29e4ce0d1e23b0a