### PR TITLE
feat: add automatic codec negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Configureer uw SIP accountgegevens via de instellingen van de app in Homey zodat
 
 Optioneel kan een STUN-server opgegeven worden om het publieke IP-adres en poorten te bepalen. Dit kan helpen bij NAT-problemen bij inkomende SIP en RTP.
 
-In de instellingen kan tevens de gewenste codec (PCMU of PCMA) worden gekozen.
+In de instellingen kan de codec worden ingesteld. Standaard probeert de app
+automatisch de beste kwaliteit (PCMA) te gebruiken en valt terug op PCMU als
+de SIP-server dit vereist.
 
 Deze app gebruikt [`mpg123-decoder`](https://www.npmjs.com/package/mpg123-decoder) om MP3-bestanden naar het juiste WAV-formaat te converteren. WAV-bestanden met een ander sample rate of aantal kanalen worden automatisch omgezet naar 16-bit 8kHz mono voor gebruik in de SIP-gesprekken.

--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ class VoipPlayerApp extends Homey.App {
         sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
         local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
         local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
-        codec: (this.homey.settings.get('codec') || 'PCMU').toUpperCase(),
+        codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
         invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
         stun_server: this.homey.settings.get('stun_server') || '',

--- a/lib/buildSdpOffer.test.js
+++ b/lib/buildSdpOffer.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const { buildSdpOffer } = require('./sip_call_play');
+
+test('buildSdpOffer AUTO advertises both PCMA and PCMU', () => {
+  const sdp = buildSdpOffer('1.2.3.4', 5555, 'AUTO');
+  assert.ok(sdp.includes('m=audio 5555 RTP/AVP 8 0 101'));
+  assert.ok(sdp.includes('a=rtpmap:8 PCMA/8000'));
+  assert.ok(sdp.includes('a=rtpmap:0 PCMU/8000'));
+});

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -67,17 +67,24 @@ function buildAuthHeader(wwwAuth, { method, uri }, username, password, realmOver
   return `Digest ${params}`;
 }
 
-function buildSdpOffer(localIp, rtpPort, codec = 'PCMU') {
-  const pt = codec === 'PCMA' ? 8 : 0;
-  const codecLine = codec === 'PCMA' ? 'a=rtpmap:8 PCMA/8000' : 'a=rtpmap:0 PCMU/8000';
+function buildSdpOffer(localIp, rtpPort, codec = 'AUTO') {
+  let mLineCodecs = '0 101';
+  const codecLines = ['a=rtpmap:0 PCMU/8000'];
+  if (codec === 'PCMA') {
+    mLineCodecs = '8 101';
+    codecLines.splice(0, 1, 'a=rtpmap:8 PCMA/8000');
+  } else if (codec === 'AUTO') {
+    mLineCodecs = '8 0 101';
+    codecLines.unshift('a=rtpmap:8 PCMA/8000');
+  }
   return [
     'v=0',
     `o=- 0 0 IN IP4 ${localIp}`,
     's=-',
     `c=IN IP4 ${localIp}`,
     't=0 0',
-    `m=audio ${rtpPort} RTP/AVP ${pt} 101`,
-    codecLine,
+    `m=audio ${rtpPort} RTP/AVP ${mLineCodecs}`,
+    ...codecLines,
     'a=rtpmap:101 telephone-event/8000',
     'a=ptime:20',
     // Request two-way audio by default. The RTP stream we generate is
@@ -122,7 +129,7 @@ function buildVia(ip, port, protocol = 'UDP') {
 async function callOnce(cfg) {
   const {
     sip_domain, sip_proxy, username, auth_id, password, realm, display_name, from_user,
-    local_ip, local_sip_port, local_rtp_port, codec = 'PCMU', expires_sec, invite_timeout,
+    local_ip, local_sip_port, local_rtp_port, codec = 'AUTO', expires_sec, invite_timeout,
     stun_server, stun_port,
     sip_transport = 'UDP',
     to, wavPath, repeat: repeatRaw = 1, delay: delaySec = 2, logger = () => {}
@@ -432,4 +439,4 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
   });
 }
 
-module.exports = { callOnce, parseAuthHeader };
+module.exports = { callOnce, parseAuthHeader, buildSdpOffer };

--- a/settings/index.html
+++ b/settings/index.html
@@ -55,6 +55,7 @@
     </label>
     <label>Codec
       <select id="codec">
+        <option value="AUTO">AUTO (prefer PCMA)</option>
         <option value="PCMU">PCMU (G711u)</option>
         <option value="PCMA">PCMA (G711a)</option>
       </select>
@@ -76,7 +77,7 @@
   <script>
     function onHomeyReady(Homey) {
       const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port'];
-      const defaults = { sip_transport: 'UDP', codec: 'PCMU' };
+      const defaults = { sip_transport: 'UDP', codec: 'AUTO' };
       fields.forEach(key => {
         Homey.get(key, (err, value) => {
           if (!err && document.getElementById(key)) {


### PR DESCRIPTION
## Summary
- support AUTO codec that offers PCMA with fallback to PCMU
- expose automatic codec selection in settings and app defaults
- test SDP builder for AUTO codec behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd46ddd4833081fdd080c174833b