### PR TITLE
fix: correct codec setting definition

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -140,12 +140,17 @@
     },
     {
       "id": "codec",
-      "type": "enum",
+      "type": "dropdown",
       "title": {
         "en": "Preferred codec",
         "nl": "Voorkeurscodec"
       },
-      "values": ["AUTO","PCMU","PCMA","G722"],
+      "values": [
+        { "id": "AUTO", "label": { "en": "AUTO", "nl": "AUTO" } },
+        { "id": "PCMU", "label": { "en": "PCMU", "nl": "PCMU" } },
+        { "id": "PCMA", "label": { "en": "PCMA", "nl": "PCMA" } },
+        { "id": "G722", "label": { "en": "G722", "nl": "G722" } }
+      ],
       "value": "AUTO"
     },
     {

--- a/app.json
+++ b/app.json
@@ -141,12 +141,17 @@
     },
     {
       "id": "codec",
-      "type": "enum",
+      "type": "dropdown",
       "title": {
         "en": "Preferred codec",
         "nl": "Voorkeurscodec"
       },
-      "values": ["AUTO","PCMU","PCMA","G722"],
+      "values": [
+        { "id": "AUTO", "label": { "en": "AUTO", "nl": "AUTO" } },
+        { "id": "PCMU", "label": { "en": "PCMU", "nl": "PCMU" } },
+        { "id": "PCMA", "label": { "en": "PCMA", "nl": "PCMA" } },
+        { "id": "G722", "label": { "en": "G722", "nl": "G722" } }
+      ],
       "value": "AUTO"
     },
     {


### PR DESCRIPTION
## Summary
- use `dropdown` for codec setting instead of unsupported `enum`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c16a0ad4833087fd7b04c8510070