### PR TITLE
Add G722 codec option to settings UI

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -58,6 +58,7 @@
         <option value="AUTO">AUTO (prefer PCMA)</option>
         <option value="PCMU">PCMU (G711u)</option>
         <option value="PCMA">PCMA (G711a)</option>
+        <option value="G722">G722</option>
       </select>
     </label>
     <label>REGISTER Expires (s)


### PR DESCRIPTION
## Summary
- add G722 to codec selection in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c3a71b888330aaff2f170e6c3f21