### PR TITLE
refactor: streamline audio processing loops

### DIFF
--- a/lib/wav_utils.js
+++ b/lib/wav_utils.js
@@ -245,13 +245,17 @@ function decodeWavToPcm16Mono16k(wavPath) {
 }
 
 function mergeChannels(channels) {
-  if (channels.length === 1) return channels[0];
+  const numChannels = channels.length;
+  if (numChannels === 1) return channels[0];
   const length = channels[0].length;
   const out = new Float32Array(length);
+  const inv = 1 / numChannels;
   for (let i = 0; i < length; i++) {
     let sum = 0;
-    for (const ch of channels) sum += ch[i];
-    out[i] = sum / channels.length;
+    for (let c = 0; c < numChannels; c++) {
+      sum += channels[c][i];
+    }
+    out[i] = sum * inv;
   }
   return out;
 }
@@ -272,11 +276,12 @@ function resampleFloat32(data, inRate, outRate) {
 }
 
 function floatToInt16(data) {
-  const out = new Int16Array(data.length);
-  for (let i = 0; i < data.length; i++) {
+  const len = data.length;
+  const out = new Int16Array(len);
+  for (let i = 0; i < len; i++) {
     let s = data[i];
     if (s > 1) s = 1;
-    if (s < -1) s = -1;
+    else if (s < -1) s = -1;
     out[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
   }
   return out;


### PR DESCRIPTION
## Summary
- optimize channel merging using indexed loops and a precomputed divisor
- cache array length and clamp checks when converting floats to PCM16

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2cdd3ab7883308eabec1b643503f0