### PR TITLE
Optimize audio playback memory usage

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,7 +162,11 @@ class HomeyPhoneHomeApp extends Homey.App {
     if (s && s.url) {
       await this._downloadToFile(s.url, dest);
     } else if (s && s.data) {
-      fs.writeFileSync(dest, Buffer.from(s.data, 'base64'));
+      // Writing large base64 blobs via Buffer.from() temporarily allocates
+      // an additional copy of the decoded data in memory. By writing the
+      // base64 string directly to disk we avoid this duplication and reduce
+      // peak memory usage when handling bigger sound files.
+      await fs.promises.writeFile(dest, s.data, { encoding: 'base64' });
     } else { throw new Error('Soundboard gaf geen url/data terug'); }
     return await require('./lib/wav_utils').ensureWavPcm16Mono16k(dest);
   }

--- a/lib/sip_call_play.js
+++ b/lib/sip_call_play.js
@@ -405,8 +405,9 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
   let ts  = Math.floor(Math.random() * 0xffffffff);
 
   const frameSize = 160; // 20ms @8kHz
-  const fullBuffer = Buffer.concat(Array(Math.max(1, repeats)).fill(encoded));
-  const totalFrames = Math.ceil(fullBuffer.length / frameSize);
+  const repeatsN = Math.max(1, repeats);
+  const framesPerRepeat = Math.ceil(encoded.length / frameSize);
+  const totalFrames = framesPerRepeat * repeatsN;
 
   sock.bind(localPort, localIp, () => {
     const t0 = process.hrtime.bigint();
@@ -431,8 +432,8 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
         for (let k = 0; k < 10; k++) sock.send(buildPkt(silence), remote.port, remote.ip);
         sock.close(); onDone && onDone(); return;
       }
-      const startIdx = i * frameSize;
-      const chunk = fullBuffer.slice(startIdx, Math.min(startIdx + frameSize, fullBuffer.length));
+      const startIdx = (i % framesPerRepeat) * frameSize;
+      const chunk = encoded.slice(startIdx, Math.min(startIdx + frameSize, encoded.length));
       const payload = (chunk.length === frameSize) ? chunk : Buffer.concat([chunk, Buffer.alloc(frameSize - chunk.length, 0xFF)]);
       sock.send(buildPkt(payload), remote.port, remote.ip);
 


### PR DESCRIPTION
## Summary
- avoid double-buffering soundboard base64 data when writing to disk
- stream RTP audio repeats without concatenating full buffer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d6ef5b408330a0a1b0ae6eeaa8e2