### PR TITLE
Add logging and expand audio format support

### DIFF
--- a/app.js
+++ b/app.js
@@ -174,7 +174,7 @@ class HomeyPhoneHomeApp extends Homey.App {
       // peak memory usage when handling bigger sound files.
       await fs.promises.writeFile(dest, s.data, { encoding: 'base64' });
     } else { throw new Error('Soundboard gaf geen url/data terug'); }
-    return await ensureWavPcm16Mono16k(dest);
+    return await ensureWavPcm16Mono16k(dest, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
   }
   async _ensureLocalWav(urlOrPath) {
     let local = urlOrPath;
@@ -182,7 +182,7 @@ class HomeyPhoneHomeApp extends Homey.App {
       local = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
       await this._downloadToFile(urlOrPath, local);
     } else { if (!fs.existsSync(urlOrPath)) throw new Error('Bestand niet gevonden: '+urlOrPath); }
-    return await ensureWavPcm16Mono16k(local);
+    return await ensureWavPcm16Mono16k(local, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
   }
   async _downloadToFile(url, destPath) {
     const client = url.startsWith('https')?https:http;

--- a/lib/wav_utils.cjs
+++ b/lib/wav_utils.cjs
@@ -7,6 +7,8 @@ const os = require('os');
 // need to use a dynamic import to load it. This avoids `require()`
 // errors when decoding MP3 files.
 let MPEGDecoder;
+let OggVorbisDecoder;
+let FlacDecoder;
 
 function readWavPcm16Mono(path, expectedRate) {
   const buf = fs.readFileSync(path);
@@ -99,15 +101,14 @@ function pcm16ToAlawBuffer(pcm) {
   return out;
 }
 
-async function ensureWavPcm16Mono(srcPath, targetRate) {
+async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}) {
+  logger('info', `0%: controleer ${srcPath}`);
   try {
     readWavPcm16Mono(srcPath, targetRate);
+    logger('info', '100%: geen conversie nodig');
     return srcPath;
   } catch (e) {
-    // If the file is a WAV but in the wrong format (e.g. stereo or
-    // different sample rate), convert it to the required PCM16 mono 8k
-    // format. If that fails, or if it's not a WAV at all, fall back to
-    // attempting MP3 decoding.
+    logger('info', 'Conversie vereist');
     if (e.message && (
       e.message.includes('Mono vereist') ||
       e.message.includes('8000 Hz vereist') ||
@@ -116,36 +117,44 @@ async function ensureWavPcm16Mono(srcPath, targetRate) {
       e.message.includes('Alleen PCM ondersteund')
     )) {
       try {
+        logger('info', '10%: WAV converteren');
         const pcm = targetRate === 8000 ? decodeWavToPcm16Mono8k(srcPath) : decodeWavToPcm16Mono16k(srcPath);
+        logger('info', '60%: WAV gedecodeerd');
         const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
         (targetRate===8000?writeWavPcm16Mono8k:writeWavPcm16Mono16k)(dest, pcm);
         readWavPcm16Mono(dest, targetRate);
+        logger('info', '100%: conversie gereed');
         return dest;
-      } catch (_) {
-        // fall through to MP3 decoding
+      } catch (err) {
+        logger('error', `WAV conversie mislukt: ${err.message || err}`);
       }
     }
-    // When the source isn't a valid WAV file, attempt to treat it as an MP3
-    // regardless of the file extension. This covers scenarios where MP3
-    // content is stored with a `.wav` extension (e.g. files downloaded from
-    // external sources or Homey soundboard entries).
-    if (e.message && e.message.includes('Geen geldige WAV')) {
+    const decoders = [
+      { name: 'MP3', fn: targetRate===8000?decodeMp3ToPcm16Mono8k:decodeMp3ToPcm16Mono16k },
+      { name: 'OGG', fn: targetRate===8000?decodeOggToPcm16Mono8k:decodeOggToPcm16Mono16k },
+      { name: 'FLAC', fn: targetRate===8000?decodeFlacToPcm16Mono8k:decodeFlacToPcm16Mono16k }
+    ];
+    for (const d of decoders) {
       try {
-        const pcm = await (targetRate===8000?decodeMp3ToPcm16Mono8k:decodeMp3ToPcm16Mono16k)(srcPath);
+        logger('info', `10%: probeer ${d.name}`);
+        const pcm = await d.fn(srcPath);
+        logger('info', `60%: ${d.name} gedecodeerd`);
         const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
         (targetRate===8000?writeWavPcm16Mono8k:writeWavPcm16Mono16k)(dest, pcm);
-        readWavPcm16Mono(dest, targetRate); // throws if conversion failed
+        readWavPcm16Mono(dest, targetRate);
+        logger('info', '100%: conversie gereed');
         return dest;
-      } catch (_) {
-        // fall through and rethrow original error if MP3 decoding fails
+      } catch (err) {
+        logger('error', `${d.name} conversie mislukt: ${err.message || err}`);
       }
     }
+    logger('error', `Conversie mislukt: ${e.message || e}`);
     throw e;
   }
 }
 
-function ensureWavPcm16Mono8k(srcPath) { return ensureWavPcm16Mono(srcPath, 8000); }
-function ensureWavPcm16Mono16k(srcPath) { return ensureWavPcm16Mono(srcPath, 16000); }
+function ensureWavPcm16Mono8k(srcPath, logger) { return ensureWavPcm16Mono(srcPath, 8000, logger); }
+function ensureWavPcm16Mono16k(srcPath, logger) { return ensureWavPcm16Mono(srcPath, 16000, logger); }
 
 async function decodeMp3ToPcm16Mono8k(mp3Path) {
   if (!MPEGDecoder) {
@@ -166,6 +175,50 @@ async function decodeMp3ToPcm16Mono16k(mp3Path) {
   await decoder.ready;
   const mp3 = fs.readFileSync(mp3Path);
   const { channelData, sampleRate } = decoder.decode(mp3);
+  const mono = mergeChannels(channelData);
+  const resampled = resampleFloat32(mono, sampleRate, 16000);
+  return floatToInt16(resampled);
+}
+
+async function decodeOggToPcm16Mono8k(oggPath) {
+  if (!OggVorbisDecoder) ({ OggVorbisDecoder } = await import('@wasm-audio-decoders/ogg-vorbis'));
+  const decoder = new OggVorbisDecoder();
+  await decoder.ready;
+  const ogg = fs.readFileSync(oggPath);
+  const { channelData, sampleRate } = decoder.decode(ogg);
+  const mono = mergeChannels(channelData);
+  const resampled = resampleFloat32(mono, sampleRate, 8000);
+  return floatToInt16(resampled);
+}
+
+async function decodeOggToPcm16Mono16k(oggPath) {
+  if (!OggVorbisDecoder) ({ OggVorbisDecoder } = await import('@wasm-audio-decoders/ogg-vorbis'));
+  const decoder = new OggVorbisDecoder();
+  await decoder.ready;
+  const ogg = fs.readFileSync(oggPath);
+  const { channelData, sampleRate } = decoder.decode(ogg);
+  const mono = mergeChannels(channelData);
+  const resampled = resampleFloat32(mono, sampleRate, 16000);
+  return floatToInt16(resampled);
+}
+
+async function decodeFlacToPcm16Mono8k(flacPath) {
+  if (!FlacDecoder) ({ FlacDecoder } = await import('@wasm-audio-decoders/flac'));
+  const decoder = new FlacDecoder();
+  await decoder.ready;
+  const flac = fs.readFileSync(flacPath);
+  const { channelData, sampleRate } = decoder.decode(flac);
+  const mono = mergeChannels(channelData);
+  const resampled = resampleFloat32(mono, sampleRate, 8000);
+  return floatToInt16(resampled);
+}
+
+async function decodeFlacToPcm16Mono16k(flacPath) {
+  if (!FlacDecoder) ({ FlacDecoder } = await import('@wasm-audio-decoders/flac'));
+  const decoder = new FlacDecoder();
+  await decoder.ready;
+  const flac = fs.readFileSync(flacPath);
+  const { channelData, sampleRate } = decoder.decode(flac);
   const mono = mergeChannels(channelData);
   const resampled = resampleFloat32(mono, sampleRate, 16000);
   return floatToInt16(resampled);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "com.marco.voipplayer",
       "version": "0.1.1",
       "dependencies": {
+        "@wasm-audio-decoders/flac": "^0.2.8",
+        "@wasm-audio-decoders/ogg-vorbis": "^0.1.18",
         "mpg123-decoder": "^1.0.2",
         "sip": "^0.0.6"
       },
@@ -31,11 +33,45 @@
         "simple-yenc": "^1.0.4"
       }
     },
+    "node_modules/@wasm-audio-decoders/flac": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/flac/-/flac-0.2.8.tgz",
+      "integrity": "sha512-CxvylHiUmtCrf0hUSzYQlD9RtoY/LsPuKR8M6ZjtQrXHzSLir0whWjPs1yb+hDZdK8R1NbESHcz2ZV88eMcKUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "9.0.7",
+        "codec-parser": "2.5.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
+    "node_modules/@wasm-audio-decoders/ogg-vorbis": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/ogg-vorbis/-/ogg-vorbis-0.1.18.tgz",
+      "integrity": "sha512-kEg6b5vW4wAXfGAqe5wzvSuAs2FEhPY/rniYF/Gx3rgxQcPiRI86SBAyIRWFJ7O4CY/JJHX57B1OCDueMlBSLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "9.0.7",
+        "codec-parser": "2.5.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
+    },
+    "node_modules/codec-parser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/codec-parser/-/codec-parser-2.5.0.tgz",
+      "integrity": "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==",
+      "license": "LGPL-3.0-or-later"
     },
     "node_modules/mpg123-decoder": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "mpg123-decoder": "^1.0.2",
-    "sip": "^0.0.6"
+    "sip": "^0.0.6",
+    "@wasm-audio-decoders/ogg-vorbis": "^0.1.18",
+    "@wasm-audio-decoders/flac": "^0.2.8"
   },
   "homey": {
     "compose": true


### PR DESCRIPTION
## Summary
- log progress and errors during audio conversion
- support OGG Vorbis and FLAC sources for SIP calls
- expose conversion logs in app when preparing audio

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2dc76a6a08330a95a4f7997381e12