### PR TITLE
Fix Danish translation in flow action JSON

### DIFF
--- a/.homeycompose/flow/actions/call_and_play_url.json
+++ b/.homeycompose/flow/actions/call_and_play_url.json
@@ -52,7 +52,7 @@
       "title": {
         "en": "URL or path to WAV (8kHz mono)",
         "nl": "URL of pad naar WAV (8kHz mono)",
-        "da": "URL eller sti til WAV (8kHz mono)",
+        "da": "URL eller sti til WAV (8 kHz mono)",
         "de": "URL oder Pfad zu WAV (8kHz mono)",
         "es": "URL o ruta a WAV (8kHz mono)",
         "fr": "URL ou chemin vers WAV (8kHz mono)",


### PR DESCRIPTION
## Summary
- correct Danish WAV description in `call_and_play_url` flow action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e57361e48330850071c734bd4e92