### PR TITLE
feat: add cached audio management

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import os from 'os';
 import http from 'http';
 import https from 'https';
+import crypto from 'crypto';
 import sipCallPlay from './lib/sip_call_play.cjs';
 import wavUtils from './lib/wav_utils.cjs';
 
@@ -13,6 +14,14 @@ const { ensureWavPcm16Mono16k } = wavUtils;
 class HomeyPhoneHomeApp extends Homey.App {
   async onInit() {
     this.log('Homey Phone Home app init');
+
+    this._cacheDir = path.join(os.tmpdir(), 'phonehome_cache');
+    await fs.promises.mkdir(this._cacheDir, { recursive: true });
+    this._cacheIndex = this.homey.settings.get('cache_index') || {};
+    this._purgeCache();
+    this.homey.api.get('/cache', async (req,res)=>{ res.json(await this._listCache()); });
+    this.homey.api.post('/cache/:id/delete', async (req,res)=>{ await this._deleteCache(req.params.id); res.json({success:true}); });
+    this.homey.api.post('/cache/:id/permanent', async (req,res)=>{ await this._setPermanent(req.params.id, !!(req.body&&req.body.permanent)); res.json({success:true}); });
 
     this._triggerCompleted = this.homey.flow.getTriggerCard('call_completed');
 
@@ -162,27 +171,39 @@ class HomeyPhoneHomeApp extends Homey.App {
   }
 
   async _resolveSoundboardToWav(soundArg) {
-    const sb = await this.homey.api.getApiApp('com.athom.soundboard');
-    const s = await sb.get(`/sounds/${encodeURIComponent(soundArg.id)}`);
-    const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
-    if (s && s.url) {
-      await this._downloadToFile(s.url, dest);
-    } else if (s && s.data) {
-      // Writing large base64 blobs via Buffer.from() temporarily allocates
-      // an additional copy of the decoded data in memory. By writing the
-      // base64 string directly to disk we avoid this duplication and reduce
-      // peak memory usage when handling bigger sound files.
-      await fs.promises.writeFile(dest, s.data, { encoding: 'base64' });
-    } else { throw new Error('Soundboard gaf geen url/data terug'); }
-    return await ensureWavPcm16Mono16k(dest, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
+    return this._getCachedOrCreate(`sb:${soundArg.id}`, async (cachePath) => {
+      const sb = await this.homey.api.getApiApp('com.athom.soundboard');
+      const s = await sb.get(`/sounds/${encodeURIComponent(soundArg.id)}`);
+      const tmp = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+      if (s && s.url) {
+        await this._downloadToFile(s.url, tmp);
+      } else if (s && s.data) {
+        await fs.promises.writeFile(tmp, s.data, { encoding: 'base64' });
+      } else { throw new Error('Soundboard gaf geen url/data terug'); }
+      const wav = await ensureWavPcm16Mono16k(tmp, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
+      if (wav !== cachePath) await fs.promises.copyFile(wav, cachePath);
+      if (wav !== tmp) { try { await fs.promises.unlink(wav); } catch(e){} }
+      try { await fs.promises.unlink(tmp); } catch(e){}
+    });
   }
   async _ensureLocalWav(urlOrPath) {
-    let local = urlOrPath;
-    if (/^https?:\/\//i.test(urlOrPath)) {
-      local = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
-      await this._downloadToFile(urlOrPath, local);
-    } else { if (!fs.existsSync(urlOrPath)) throw new Error('Bestand niet gevonden: '+urlOrPath); }
-    return await ensureWavPcm16Mono16k(local, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
+    const isUrl = /^https?:\/\//i.test(urlOrPath);
+    const key = isUrl ? `url:${urlOrPath}` : `path:${path.resolve(urlOrPath)}`;
+    return this._getCachedOrCreate(key, async (cachePath) => {
+      let src = urlOrPath;
+      let tmp;
+      if (isUrl) {
+        tmp = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+        await this._downloadToFile(urlOrPath, tmp);
+        src = tmp;
+      } else {
+        if (!fs.existsSync(urlOrPath)) throw new Error('Bestand niet gevonden: '+urlOrPath);
+      }
+      const wav = await ensureWavPcm16Mono16k(src, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
+      if (wav !== cachePath) await fs.promises.copyFile(wav, cachePath);
+      if (wav !== src) { try { await fs.promises.unlink(wav); } catch(e){} }
+      if (isUrl && src && fs.existsSync(src)) { try { await fs.promises.unlink(src); } catch(e){} }
+    });
   }
   async _downloadToFile(url, destPath) {
     const client = url.startsWith('https')?https:http;
@@ -193,6 +214,68 @@ class HomeyPhoneHomeApp extends Homey.App {
         res.pipe(file); file.on('finish', ()=>file.close(resolve));
       }); req.on('error', reject);
     });
+  }
+
+  _cacheDays() {
+    return Number(this.homey.settings.get('cache_days') || 2);
+  }
+
+  _saveCacheIndex() {
+    this.homey.settings.set('cache_index', this._cacheIndex);
+  }
+
+  _purgeCache() {
+    const maxAge = this._cacheDays() * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    for (const [id, meta] of Object.entries(this._cacheIndex)) {
+      if (!meta.permanent && now - (meta.lastUsed || 0) > maxAge) {
+        try { fs.unlinkSync(path.join(this._cacheDir, meta.file)); } catch(e){}
+        delete this._cacheIndex[id];
+      }
+    }
+    this._saveCacheIndex();
+  }
+
+  async _listCache() {
+    return Object.entries(this._cacheIndex).map(([id, meta]) => ({
+      id,
+      key: meta.key,
+      permanent: !!meta.permanent,
+      lastUsed: meta.lastUsed
+    }));
+  }
+
+  async _deleteCache(id) {
+    const meta = this._cacheIndex[id];
+    if (meta) {
+      try { await fs.promises.unlink(path.join(this._cacheDir, meta.file)); } catch(e){}
+      delete this._cacheIndex[id];
+      this._saveCacheIndex();
+    }
+  }
+
+  async _setPermanent(id, val) {
+    if (this._cacheIndex[id]) {
+      this._cacheIndex[id].permanent = !!val;
+      this._saveCacheIndex();
+    }
+  }
+
+  async _getCachedOrCreate(key, creator) {
+    await fs.promises.mkdir(this._cacheDir, { recursive: true });
+    this._purgeCache();
+    const id = crypto.createHash('sha1').update(key).digest('hex');
+    const file = path.join(this._cacheDir, `${id}.wav`);
+    const meta = this._cacheIndex[id];
+    if (meta && fs.existsSync(file)) {
+      meta.lastUsed = Date.now();
+      this._saveCacheIndex();
+      return file;
+    }
+    await creator(file);
+    this._cacheIndex[id] = { key, file: path.basename(file), permanent: false, lastUsed: Date.now() };
+    this._saveCacheIndex();
+    return file;
   }
 }
 export default HomeyPhoneHomeApp;

--- a/settings/index.html
+++ b/settings/index.html
@@ -9,72 +9,94 @@
     label { display: block; margin-top: 10px; }
     input { width: 100%; box-sizing: border-box; }
     button { margin-top: 20px; }
+    #tabs button { margin-right: 10px; }
+    #cache-list td { padding: 4px 8px; }
   </style>
 </head>
 <body>
-  <h1>SIP Settings</h1>
-  <form id="settings-form">
-    <label>SIP Domain/Registrar
-      <input id="sip_domain" type="text" />
-    </label>
-    <label>SIP Proxy/Request-URI host (optional)
-      <input id="sip_proxy" type="text" />
-    </label>
-    <label>Username
-      <input id="username" type="text" />
-    </label>
-    <label>Authentication ID (optional)
-      <input id="auth_id" type="text" />
-    </label>
-    <label>Password
-      <input id="password" type="password" />
-    </label>
-    <label>Realm (optional)
-      <input id="realm" type="text" />
-    </label>
-    <label>Display name (From)
-      <input id="display_name" type="text" />
-    </label>
-    <label>From user
-      <input id="from_user" type="text" />
-    </label>
-    <label>Local IP (Homey)
-      <input id="local_ip" type="text" />
-    </label>
-    <label>SIP Transport
-      <select id="sip_transport">
-        <option value="UDP">UDP</option>
-        <option value="TCP">TCP</option>
-      </select>
-    </label>
-    <label>Local SIP port
-      <input id="local_sip_port" type="number" />
-    </label>
-    <label>Local RTP port
-      <input id="local_rtp_port" type="number" />
-    </label>
-    <label>Codec
-      <select id="codec">
-        <option value="AUTO">AUTO (prefer PCMA)</option>
-        <option value="PCMU">PCMU (G711u)</option>
-        <option value="PCMA">PCMA (G711a)</option>
-        <option value="G722">G722</option>
-      </select>
-    </label>
-    <label>REGISTER Expires (s)
-      <input id="expires_sec" type="number" />
-    </label>
-    <label>Invite timeout (s)
-      <input id="invite_timeout" type="number" />
-    </label>
-    <label>STUN server (optional)
-      <input id="stun_server" type="text" />
-    </label>
-    <label>STUN port
-      <input id="stun_port" type="number" />
-    </label>
-    <button type="submit">Save</button>
-  </form>
+  <div id="tabs">
+    <button data-tab="sip">SIP</button>
+    <button data-tab="cache">Cache</button>
+  </div>
+
+  <div id="tab-sip">
+    <h1>SIP Settings</h1>
+    <form id="settings-form">
+      <label>SIP Domain/Registrar
+        <input id="sip_domain" type="text" />
+      </label>
+      <label>SIP Proxy/Request-URI host (optional)
+        <input id="sip_proxy" type="text" />
+      </label>
+      <label>Username
+        <input id="username" type="text" />
+      </label>
+      <label>Authentication ID (optional)
+        <input id="auth_id" type="text" />
+      </label>
+      <label>Password
+        <input id="password" type="password" />
+      </label>
+      <label>Realm (optional)
+        <input id="realm" type="text" />
+      </label>
+      <label>Display name (From)
+        <input id="display_name" type="text" />
+      </label>
+      <label>From user
+        <input id="from_user" type="text" />
+      </label>
+      <label>Local IP (Homey)
+        <input id="local_ip" type="text" />
+      </label>
+      <label>SIP Transport
+        <select id="sip_transport">
+          <option value="UDP">UDP</option>
+          <option value="TCP">TCP</option>
+        </select>
+      </label>
+      <label>Local SIP port
+        <input id="local_sip_port" type="number" />
+      </label>
+      <label>Local RTP port
+        <input id="local_rtp_port" type="number" />
+      </label>
+      <label>Codec
+        <select id="codec">
+          <option value="AUTO">AUTO (prefer PCMA)</option>
+          <option value="PCMU">PCMU (G711u)</option>
+          <option value="PCMA">PCMA (G711a)</option>
+          <option value="G722">G722</option>
+        </select>
+      </label>
+      <label>REGISTER Expires (s)
+        <input id="expires_sec" type="number" />
+      </label>
+      <label>Invite timeout (s)
+        <input id="invite_timeout" type="number" />
+      </label>
+      <label>STUN server (optional)
+        <input id="stun_server" type="text" />
+      </label>
+      <label>STUN port
+        <input id="stun_port" type="number" />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  </div>
+
+  <div id="tab-cache" style="display:none;">
+    <h1>Cache Settings</h1>
+    <form id="cache-form">
+      <label>Cache retention (days)
+        <input id="cache_days" type="number" min="0" />
+      </label>
+      <button type="submit">Save</button>
+    </form>
+    <h2>Cached files</h2>
+    <table id="cache-list"></table>
+  </div>
+
   <script>
     function onHomeyReady(Homey) {
       const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port'];
@@ -102,8 +124,71 @@
         });
         Homey.alert('Settings saved');
       });
+
+      const cacheFields = ['cache_days'];
+      const cacheDefaults = { cache_days: 2 };
+      cacheFields.forEach(key => {
+        Homey.get(key, (err, value) => {
+          if (!err && document.getElementById(key)) {
+            const v = value !== undefined && value !== null && value !== '' ? value : (cacheDefaults[key] || '');
+            document.getElementById(key).value = v;
+          }
+        });
+      });
+      document.getElementById('cache-form').addEventListener('submit', e => {
+        e.preventDefault();
+        cacheFields.forEach(key => {
+          const input = document.getElementById(key);
+          let val = Number(input.value);
+          if (isNaN(val) || val < 0) val = 0;
+          Homey.set(key, val, err => { if (err) console.error(err); });
+        });
+        Homey.alert('Settings saved');
+      });
+
+      function refreshCacheList() {
+        Homey.api('GET', '/cache', (err, list) => {
+          if (err) return console.error(err);
+          const table = document.getElementById('cache-list');
+          table.innerHTML = '';
+          (list || []).forEach(item => {
+            const tr = document.createElement('tr');
+            const name = document.createElement('td');
+            name.textContent = item.key;
+            tr.appendChild(name);
+            const permTd = document.createElement('td');
+            const chk = document.createElement('input');
+            chk.type = 'checkbox';
+            chk.checked = item.permanent;
+            chk.addEventListener('change', () => {
+              Homey.api('POST', `/cache/${item.id}/permanent`, { permanent: chk.checked }, () => refreshCacheList());
+            });
+            permTd.appendChild(chk);
+            tr.appendChild(permTd);
+            const delTd = document.createElement('td');
+            const delBtn = document.createElement('button');
+            delBtn.textContent = 'Delete';
+            delBtn.addEventListener('click', () => {
+              Homey.api('POST', `/cache/${item.id}/delete`, {}, () => refreshCacheList());
+            });
+            delTd.appendChild(delBtn);
+            tr.appendChild(delTd);
+            table.appendChild(tr);
+          });
+        });
+      }
+      refreshCacheList();
+
+      document.querySelectorAll('#tabs button').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('[id^="tab-"]').forEach(div => div.style.display = 'none');
+          document.getElementById('tab-' + btn.dataset.tab).style.display = 'block';
+        });
+      });
+
       Homey.ready();
     }
   </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add file cache with configurable retention for audio conversions
- provide settings UI to view and manage cached files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef9c044083309f2c165b255670a8