### PR TITLE
Prefill default STUN server and port

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
         invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
-        stun_server: this.homey.settings.get('stun_server') || '',
+        stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
         stun_port: Number(this.homey.settings.get('stun_port') || 3478)
       };
 
@@ -119,7 +119,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
         invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
-        stun_server: this.homey.settings.get('stun_server') || '',
+        stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
         stun_port: Number(this.homey.settings.get('stun_port') || 3478)
       };
 

--- a/settings/index.html
+++ b/settings/index.html
@@ -78,7 +78,12 @@
   <script>
     function onHomeyReady(Homey) {
       const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port'];
-      const defaults = { sip_transport: 'UDP', codec: 'AUTO' };
+      const defaults = {
+        sip_transport: 'UDP',
+        codec: 'AUTO',
+        stun_server: 'stun.l.google.com',
+        stun_port: 3478
+      };
       fields.forEach(key => {
         Homey.get(key, (err, value) => {
           if (!err && document.getElementById(key)) {


### PR DESCRIPTION
## Summary
- default to Google's STUN server and port in SIP call config
- pre-populate STUN settings so users can override

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2f87304a48330bee14fa8b66ed092