### PR TITLE
feat: cache converted audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Geluidsbestanden in WAV of MP3 worden automatisch geconverteerd naar het geschik
 Uiteraard des te groter de geluidsfile des te langer het duurt voor de start van de sip call
 
 Belangrijke meldingen kan je dus het beste al in het juiste formaat in soundboard of elders klaar hebben staan.
+Geconverteerde geluidsbestanden worden standaard 3 dagen in cache bewaard (instelbaar via de app-instellingen) zodat vaak gebruikte bestanden niet telkens opnieuw geconverteerd hoeven te worden.

--- a/app.js
+++ b/app.js
@@ -187,7 +187,8 @@ class HomeyPhoneHomeApp extends Homey.App {
       // peak memory usage when handling bigger sound files.
       await fs.promises.writeFile(dest, s.data, { encoding: 'base64' });
     } else { throw new Error('Soundboard gaf geen url/data terug'); }
-    return await ensureWavPcm16Mono16k(dest, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
+    const cacheDays = Number(this.homey.settings.get('cache_days') || 3);
+    return await ensureWavPcm16Mono16k(dest, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)), cacheDays);
   }
   async _ensureLocalWav(urlOrPath) {
     let local = urlOrPath;
@@ -195,7 +196,8 @@ class HomeyPhoneHomeApp extends Homey.App {
       local = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
       await this._downloadToFile(urlOrPath, local);
     } else { if (!fs.existsSync(urlOrPath)) throw new Error('Bestand niet gevonden: '+urlOrPath); }
-    return await ensureWavPcm16Mono16k(local, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)));
+    const cacheDays = Number(this.homey.settings.get('cache_days') || 3);
+    return await ensureWavPcm16Mono16k(local, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)), cacheDays);
   }
   async _downloadToFile(url, destPath) {
     const client = url.startsWith('https')?https:http;

--- a/lib/wav_utils.cjs
+++ b/lib/wav_utils.cjs
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 
 // `mpg123-decoder` is an ES module. In a CommonJS environment we
 // need to use a dynamic import to load it. This avoids `require()`
@@ -101,12 +102,33 @@ function pcm16ToAlawBuffer(pcm) {
   return out;
 }
 
-async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}) {
+async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}, cacheDays = 0) {
+  const cacheMs = cacheDays > 0 ? cacheDays * 24 * 60 * 60 * 1000 : 0;
+  let cacheFile = null;
+  if (cacheMs) {
+    try {
+      const buf = fs.readFileSync(srcPath);
+      const hash = crypto.createHash('md5').update(buf).digest('hex');
+      const cacheDir = path.join(os.tmpdir(), 'voip_cache');
+      fs.mkdirSync(cacheDir, { recursive: true });
+      cacheFile = path.join(cacheDir, `${hash}_${targetRate}.wav`);
+      try {
+        const st = fs.statSync(cacheFile);
+        if (Date.now() - st.mtimeMs < cacheMs) {
+          logger('info', '100%: gebruik cache');
+          return cacheFile;
+        }
+        fs.unlinkSync(cacheFile);
+      } catch {}
+    } catch {}
+  }
+
   logger('info', `0%: controleer ${srcPath}`);
   try {
     readWavPcm16Mono(srcPath, targetRate);
     logger('info', '100%: geen conversie nodig');
-    return srcPath;
+    if (cacheFile) fs.copyFileSync(srcPath, cacheFile);
+    return cacheFile || srcPath;
   } catch (e) {
     logger('info', 'Conversie vereist');
     if (e.message && (
@@ -120,7 +142,7 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}) {
         logger('info', '10%: WAV converteren');
         const pcm = targetRate === 8000 ? decodeWavToPcm16Mono8k(srcPath) : decodeWavToPcm16Mono16k(srcPath);
         logger('info', '60%: WAV gedecodeerd');
-        const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+        const dest = cacheFile || path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
         (targetRate===8000?writeWavPcm16Mono8k:writeWavPcm16Mono16k)(dest, pcm);
         readWavPcm16Mono(dest, targetRate);
         logger('info', '100%: conversie gereed');
@@ -139,7 +161,7 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}) {
         logger('info', `10%: probeer ${d.name}`);
         const pcm = await d.fn(srcPath);
         logger('info', `60%: ${d.name} gedecodeerd`);
-        const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
+        const dest = cacheFile || path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
         (targetRate===8000?writeWavPcm16Mono8k:writeWavPcm16Mono16k)(dest, pcm);
         readWavPcm16Mono(dest, targetRate);
         logger('info', '100%: conversie gereed');
@@ -153,8 +175,8 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}) {
   }
 }
 
-function ensureWavPcm16Mono8k(srcPath, logger) { return ensureWavPcm16Mono(srcPath, 8000, logger); }
-function ensureWavPcm16Mono16k(srcPath, logger) { return ensureWavPcm16Mono(srcPath, 16000, logger); }
+function ensureWavPcm16Mono8k(srcPath, logger, cacheDays) { return ensureWavPcm16Mono(srcPath, 8000, logger, cacheDays); }
+function ensureWavPcm16Mono16k(srcPath, logger, cacheDays) { return ensureWavPcm16Mono(srcPath, 16000, logger, cacheDays); }
 
 async function decodeMp3ToPcm16Mono8k(mp3Path) {
   if (!MPEGDecoder) {

--- a/lib/wav_utils.test.cjs
+++ b/lib/wav_utils.test.cjs
@@ -54,3 +54,16 @@ test('ensureWavPcm16Mono8k converts wav with different sample rate', async () =>
   fs.unlinkSync(out);
   fs.unlinkSync(wav);
 });
+
+test('ensureWavPcm16Mono8k uses cache when available', async () => {
+  const mp3 = path.join(os.tmpdir(), `tone_${Date.now()}.mp3`);
+  fs.writeFileSync(mp3, Buffer.from(TONE_MP3_BASE64, 'base64'));
+  const out1 = await ensureWavPcm16Mono8k(mp3, () => {}, 1);
+  const stat1 = fs.statSync(out1);
+  const out2 = await ensureWavPcm16Mono8k(mp3, () => {}, 1);
+  const stat2 = fs.statSync(out2);
+  assert.strictEqual(out1, out2);
+  assert.strictEqual(stat1.mtimeMs, stat2.mtimeMs);
+  fs.unlinkSync(out1);
+  fs.unlinkSync(mp3);
+});

--- a/settings/index.html
+++ b/settings/index.html
@@ -73,16 +73,20 @@
     <label>STUN port
       <input id="stun_port" type="number" />
     </label>
+    <label>Cache days
+      <input id="cache_days" type="number" />
+    </label>
     <button type="submit">Save</button>
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port'];
+      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port','cache_days'];
       const defaults = {
         sip_transport: 'UDP',
         codec: 'AUTO',
         stun_server: 'stun.l.google.com',
-        stun_port: 3478
+        stun_port: 3478,
+        cache_days: 3
       };
       fields.forEach(key => {
         Homey.get(key, (err, value) => {


### PR DESCRIPTION
## Summary
- cache converted audio files and reuse them while fresh
- make cache expiration configurable via settings (default 3 days)
- document caching and cover with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fa252c0c833091a1d59b903c0549