### PR TITLE
Prefill default STUN server and port

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,7 +55,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
         invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
         stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
-        stun_port: Number(this.homey.settings.get('stun_port') || 3478)
+        stun_port: Number(this.homey.settings.get('stun_port') || 19302)
       };
 
       const to = number.includes('@') ? number : `${number}@${cfg.sip_domain}`;
@@ -120,7 +120,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
         invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
         stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
-        stun_port: Number(this.homey.settings.get('stun_port') || 3478)
+        stun_port: Number(this.homey.settings.get('stun_port') || 19302)
       };
 
       const to = number.includes('@') ? number : `${number}@${cfg.sip_domain}`;

--- a/app.json
+++ b/app.json
@@ -383,7 +383,7 @@
         "ru": "STUN порт",
         "ko": "STUN 포트"
       },
-      "value": 3478
+      "value": 19302
     }
   ],
   "icon": "assets/icon.svg",

--- a/lib/sip_call_play.cjs
+++ b/lib/sip_call_play.cjs
@@ -150,12 +150,12 @@ async function callOnce(cfg) {
   let public_rtp_port = local_rtp_port;
   if (stun_server) {
     try {
-      const sipMap = await stun.discover(stun_server, stun_port || 3478, local_ip, local_sip_port);
+      const sipMap = await stun.discover(stun_server, stun_port || 19302, local_ip, local_sip_port);
       if (sipMap && sipMap.address) {
         public_ip = sipMap.address;
         public_sip_port = sipMap.port;
       }
-      const rtpMap = await stun.discover(stun_server, stun_port || 3478, local_ip, local_rtp_port);
+      const rtpMap = await stun.discover(stun_server, stun_port || 19302, local_ip, local_rtp_port);
       if (rtpMap && rtpMap.address) {
         public_ip = rtpMap.address;
         public_rtp_port = rtpMap.port;

--- a/lib/stun_client.cjs
+++ b/lib/stun_client.cjs
@@ -3,7 +3,7 @@
 const dgram = require('dgram');
 const crypto = require('crypto');
 
-async function discover(server, port = 3478, localIp, localPort, timeout = 2000) {
+async function discover(server, port = 19302, localIp, localPort, timeout = 2000) {
   return new Promise((resolve, reject) => {
     const socket = dgram.createSocket('udp4');
     const tid = crypto.randomBytes(12);

--- a/settings/index.html
+++ b/settings/index.html
@@ -85,7 +85,7 @@
         sip_transport: 'UDP',
         codec: 'AUTO',
         stun_server: 'stun.l.google.com',
-        stun_port: 3478,
+        stun_port: 19302,
         cache_days: 3
       };
       fields.forEach(key => {


### PR DESCRIPTION
## Summary
- default to Google's STUN server and port in SIP call config
- pre-populate STUN settings so users can override
- align default STUN port with Google's endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fe1085f88330af2098e92e0e5441