### PR TITLE
Fix G.711 companding for SIP audio

### DIFF
--- a/lib/wav_utils.cjs
+++ b/lib/wav_utils.cjs
@@ -52,42 +52,65 @@ function readWavPcm16Mono16k(path) {
   return readWavPcm16Mono(path, 16000);
 }
 
+// µ-law encoding based on the reference implementation from
+// https://github.com/rochars/alawmulaw (MIT License).
+const MULAW_BIAS = 0x84;
+const MULAW_CLIP = 32635;
+const MULAW_ENCODE_TABLE = [
+  0,0,1,1,2,2,2,2,3,3,3,3,3,3,3,3,
+  4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
+];
 function linearToUlaw(sample) {
   let s = sample;
-  if (s > 32767) s = 32767;
-  if (s < -32768) s = -32768;
-  const BIAS = 0x84; const CLIP = 32635;
-  const sign = (s < 0) ? 0x80 : 0x00;
-  if (s < 0) s = -s;
-  if (s > CLIP) s = CLIP;
-  s = s + BIAS;
-  let exponent = 7;
-  for (let exp = 7; exp > 0; exp--) {
-    if (s & (1 << (exp + 6))) { exponent = exp; break; }
-  }
+  let sign = (s >> 8) & 0x80;
+  if (sign !== 0) s = -s;
+  s = s + MULAW_BIAS;
+  if (s > MULAW_CLIP) s = MULAW_CLIP;
+  const exponent = MULAW_ENCODE_TABLE[(s >> 7) & 0xFF];
   const mantissa = (s >> (exponent + 3)) & 0x0F;
   return ~(sign | (exponent << 4) | mantissa) & 0xFF;
 }
 
+// A-law encoding based on the reference implementation from
+// https://github.com/rochars/alawmulaw (MIT License).
+const ALAW_LOG_TABLE = [
+  1,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4,
+  5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
+];
 function linearToAlaw(sample) {
-  let s = sample;
-  if (s > 32767) s = 32767;
-  if (s < -32768) s = -32768;
-  const sign = (s < 0) ? 0x80 : 0x00;
-  if (s < 0) s = -s;
-  let exponent = 7;
-  for (let exp = 7; exp > 0; exp--) {
-    if (s & (1 << (exp + 4))) { exponent = exp; break; }
-  }
-  let mantissa;
-  if (s < 16) {
-    mantissa = s << 4;
-    exponent = -1;
+  let s = sample === -32768 ? -32767 : sample;
+  let sign = ((~s) >> 8) & 0x80;
+  if (sign === 0) s = -s;
+  if (s > 32635) s = 32635;
+  let companded;
+  if (s >= 256) {
+    const exponent = ALAW_LOG_TABLE[(s >> 8) & 0x7F];
+    const mantissa = (s >> (exponent + 3)) & 0x0F;
+    companded = (exponent << 4) | mantissa;
   } else {
-    mantissa = (s >> (exponent + 3)) & 0x0F;
+    companded = s >> 4;
   }
-  const alaw = (exponent << 4) | mantissa;
-  return (alaw ^ 0x55) | sign;
+  return companded ^ (sign ^ 0x55);
 }
 
 function pcm16ToUlawBuffer(pcm) {

--- a/lib/wav_utils.test.cjs
+++ b/lib/wav_utils.test.cjs
@@ -3,7 +3,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { ensureWavPcm16Mono8k, readWavPcm16Mono8k, writeWavPcm16Mono8k } = require('./wav_utils.cjs');
+const { ensureWavPcm16Mono8k, readWavPcm16Mono8k, writeWavPcm16Mono8k, pcm16ToUlawBuffer, pcm16ToAlawBuffer } = require('./wav_utils.cjs');
 
 const TONE_MP3_BASE64 = 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjYwLjE2LjEwMAAAAAAAAAAAAAAA//tAwAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAAFAAAEygBRUVFRUVFRUVFRUVFRUVFRUVFRfX19fX19fX19fX19fX19fX19fX2oqKioqKioqKioqKioqKioqKioqNTU1NTU1NTU1NTU1NTU1NTU1NTU//////////////////////////8AAAAATGF2YzYwLjMxAAAAAAAAAAAAAAAAJAMGAAAAAAAABMouNstvAAAAAAD/+1DEAAAKZFMyNZeAAWiVZsM5EAAfi5ZcsuWXLLloPrrctQMuI2oJLNeE6bTvtOmM2TwcWTRgLYPQQguB0KBkfv1er1ezv496Uo8iAgcg+D78QbuX6QxwG/SCGoBn9IIcBn9IY5f3dIJBhhEMb3+zFpEMWFHRgNAeYDJ58aQGLyAYfr5ICD5r0MTgkBHA4VcAAh+wZa/DIw5IskVr/kOHOGWJkiv/kBMiLEWMS7/+XTIvF5FEx/g0FQVER7/WCoiPBpWAABx1Vr+/uIAoCkwG//tSxAaAClQtFT3sAAFnCWFVn+kKARTBUBHMDoBMwKAbzDGF5MiQjMyLOrTigR4MVsIMwkgOzA6BTMCQAgCKBZlTRteO0Ua+min9en/q/+/6Pf39C9PblOnpdgAAP1hkh0PIEwRjMXN1w9/jAWAHcwLsEyMLSXmTd4A44wXYC/P3GNcTGgyyUJSmsPc1r//ev7/6t6U8U9DoXaKRm1PeKp9qLPRuQ4n742Z/f3Nd4rG2/09NCv/eioKM0LBpQwSMzKI4bgwHYBXMEFA1DD5kI07/+1LEDgAMMFMIDX4ogS+FonGv6UCO4J4MIMAzAtwCIMApQEAdgL8E0H6kCrs+p0FVmy8/UPZ3zhJv0Mex4ubX3okLdM2OQOb0xRVykU2jdhpLm2xeuzu4z6IgAAASO109/elElZ0CiAGXOAR4Iuk/4whYDINZ0ABxYIkE2YREAxNBOvCC7g5tmilafNcz6r60q+hrrvYkqpC3dCkt7+Zbpe/7df9FcAAACABe6/RVADEQMQAwXDSwAFYiaIPHczZheBswb5oEBmDEAMxw5SZ8P/7UsQVAgsQLQ0t/2oBUAWipr2QALGPiZgYSXAXPGFtzcQn0Ujb5aqYo1RrXp3da6/uum7vp990x0CyVIfUTVV/Qz7wGDtqu8/jdg4BcwBQLzBDAjAICpgWAIGDsJwY0wrRivXMHuYbWYQgsRh2A/GEADoNAoDhxxHFtGoK2vpo1cbXM6948//p1/fXfdqru7v8Uq602L6FDTgKHb8nzHgsFokEAA/yyhgQE4LOfMBOAcSGw18MuiZaVw8ae2I0KlgUaZAAPzC4MniAsVDMMFg2//tSxByAEaTxV7m5ABDehuHPmJAAOCyBKI6hBZ3QYLKAGHImXxziiRUivxcIYDE5haADcBDhzhzjEu/kQGbHPImMwQQmUkkqv5OEHJ83JxBBJEul0yLxFv++tN0EGRRMREFRvy4fBAB3AAKSXNEoShKMnmSSTUMEQOlmAyfEECJ8BQAgS5ZE1waBrZwV5Y8r9T1f/EXKnV4NWf///okqjylMQU1FMy4xMDBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVU=';
 
@@ -15,6 +15,16 @@ test('ensureWavPcm16Mono8k converts mp3 to wav', async () => {
   assert.ok(pcm.length > 0);
   fs.unlinkSync(out);
   fs.unlinkSync(mp3);
+});
+
+test('pcm16ToUlawBuffer encodes known samples', () => {
+  const buf = pcm16ToUlawBuffer(new Int16Array([0, 1, -1, 1000, -1000]));
+  assert.deepStrictEqual(Array.from(buf), [255, 255, 127, 206, 78]);
+});
+
+test('pcm16ToAlawBuffer encodes known samples', () => {
+  const buf = pcm16ToAlawBuffer(new Int16Array([0, 1, -1, 1000, -1000]));
+  assert.deepStrictEqual(Array.from(buf), [213, 213, 85, 250, 122]);
 });
 
 test('ensureWavPcm16Mono8k handles mp3 with wav extension', async () => {


### PR DESCRIPTION
## Summary
- correct µ-law and A-law encoders using reference tables
- add tests for pcm16 µ-law/A-law conversions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ff4f8ecc8330902887913edf3670