### PR TITLE
Handle remote BYE and reduce memory usage

### DIFF
--- a/lib/sip_call_play.cjs
+++ b/lib/sip_call_play.cjs
@@ -265,6 +265,7 @@ async function callOnce(cfg) {
     let endReason = 'OK';
 
     const result = await new Promise((resolve, reject) => {
+      let rtpStream = null;
       const timer = setTimeout(() => {
         endReason = 'Request Timeout';
         reject(new Error('Invite timeout'));
@@ -307,7 +308,7 @@ async function callOnce(cfg) {
       answerTs = Date.now();
       logger('info', `Answered. RTP -> ${remote.ip}:${remote.port}`);
 
-      startRtpStream(encoded, local_ip, local_rtp_port, remote, repeat, () => {
+      rtpStream = startRtpStream(encoded, local_ip, local_rtp_port, remote, repeat, () => {
         const bye = {
           method: 'BYE',
           uri: remoteTarget || invite.uri,
@@ -348,6 +349,16 @@ async function callOnce(cfg) {
           sip.send(sip.makeResponse(req, 200, 'OK'));
           logger('info', 'Send 200 OK for BYE');
           endReason = 'Remote BYE';
+          try { rtpStream && rtpStream.stop(); } catch (_) {}
+          clearTimeout(timer);
+          setTimeout(() => {
+            try { sip.stop(); } catch (e) {}
+            resolve({
+              status: 'answered',
+              durationMs: answerTs ? (Date.now() - answerTs) : 0,
+              reason: endReason
+            });
+          }, 100);
         }
       });
     };
@@ -403,6 +414,7 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
   const SSRC = crypto.randomBytes(4).readUInt32BE(0);
   let seq = Math.floor(Math.random() * 65535);
   let ts  = Math.floor(Math.random() * 0xffffffff);
+  let stopped = false;
 
   const frameSize = 160; // 20ms @8kHz
   const repeatsN = Math.max(1, repeats);
@@ -423,14 +435,14 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
       return Buffer.concat([h, payload]);
     }
 
-    
-     
-
     function sendFrame(i) {
+      if (stopped) return;
       if (i >= totalFrames) {
         const silence = Buffer.alloc(frameSize, 0xFF);
         for (let k = 0; k < 10; k++) sock.send(buildPkt(silence), remote.port, remote.ip);
-        sock.close(); onDone && onDone(); return;
+        try { sock.close(); } catch {}
+        onDone && onDone();
+        return;
       }
       const startIdx = (i % framesPerRepeat) * frameSize;
       const chunk = encoded.slice(startIdx, Math.min(startIdx + frameSize, encoded.length));
@@ -444,6 +456,14 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
     }
     sendFrame(0);
   });
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      try { sock.close(); } catch {}
+    }
+  };
 }
 
 module.exports = { callOnce, parseAuthHeader, buildSdpOffer };

--- a/lib/wav_utils.cjs
+++ b/lib/wav_utils.cjs
@@ -130,8 +130,16 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}, cacheD
   let cacheFile = null;
   if (cacheMs) {
     try {
-      const buf = fs.readFileSync(srcPath);
-      const hash = crypto.createHash('md5').update(buf).digest('hex');
+      // Reading the entire source file into memory can spike RAM usage
+      // for large audio files. Stream the file into the hash instead to
+      // keep memory usage low.
+      const hash = await new Promise((resolve, reject) => {
+        const h = crypto.createHash('md5');
+        fs.createReadStream(srcPath)
+          .on('data', d => h.update(d))
+          .on('error', reject)
+          .on('end', () => resolve(h.digest('hex')));
+      });
       const cacheDir = path.join(os.tmpdir(), 'voip_cache');
       fs.mkdirSync(cacheDir, { recursive: true });
       cacheFile = path.join(cacheDir, `${hash}_${targetRate}.wav`);


### PR DESCRIPTION
## Summary
- stream source audio when hashing to avoid buffering entire files
- stop RTP and resolve call when the remote SIP peer sends BYE

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b302bfd9b88330b32c0394aca6675a