### PR TITLE
feat: allow manual cache clearing

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,16 @@ class HomeyPhoneHomeApp extends Homey.App {
 
     this._triggerCompleted = this.homey.flow.getTriggerCard('call_completed');
 
+    this.homey.on('clear_cache', async (_data, callback) => {
+      try {
+        const cacheDir = path.join(os.tmpdir(), 'voip_cache');
+        await fs.promises.rm(cacheDir, { recursive: true, force: true });
+        callback(null, true);
+      } catch (e) {
+        callback(e);
+      }
+    });
+
     const actionSb = this.homey.flow.getActionCard('call_and_play_soundboard');
     actionSb.registerArgumentAutocompleteListener('sound', async (query, args) => {
       try {

--- a/settings/index.html
+++ b/settings/index.html
@@ -77,6 +77,7 @@
       <input id="cache_days" type="number" />
     </label>
     <button type="submit">Save</button>
+    <button type="button" id="clear-cache">Clear cache</button>
   </form>
   <script>
     function onHomeyReady(Homey) {
@@ -110,6 +111,15 @@
           });
         });
         Homey.alert('Settings saved');
+      });
+      document.getElementById('clear-cache').addEventListener('click', () => {
+        Homey.emit('clear_cache', null, err => {
+          if (err) {
+            Homey.alert('Failed to clear cache: ' + err.message);
+          } else {
+            Homey.alert('Cache cleared');
+          }
+        });
       });
       Homey.ready();
     }


### PR DESCRIPTION
## Summary
- add Clear cache button to settings page
- handle clear_cache event in app to delete cached audio files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b307d8b9c48330896550a67fde4fb7