### PR TITLE
Reduce memory usage by lazily resampling PCM audio

### DIFF
--- a/lib/sip_call_play.cjs
+++ b/lib/sip_call_play.cjs
@@ -258,8 +258,11 @@ async function callOnce(cfg) {
     let callId = invite.headers['call-id'];
     let cseq = invite.headers.cseq.seq;
 
-    const pcm16 = readWavPcm16Mono16k(wavPath);
-    const pcm8 = pcm16Resample(pcm16, 16000, 8000);
+    let pcm16 = readWavPcm16Mono16k(wavPath);
+    // `pcm8` is only needed when the remote side negotiates an 8 kHz
+    // codec (PCMU/PCMA). Lazily derive it from the 16 kHz buffer to avoid
+    // holding two large PCM arrays in memory when it isn't required.
+    let pcm8;
 
     let answerTs = null;
     let endReason = 'OK';
@@ -280,14 +283,23 @@ async function callOnce(cfg) {
         return reject(new Error('Geen bruikbare SDP/codec'));
       }
       let encoded;
-      if (remote.pt === 9) encoded = pcm16ToG722Buffer(pcm16);
-      else if (remote.pt === 0) encoded = pcm16ToUlawBuffer(pcm8);
-      else if (remote.pt === 8) encoded = pcm16ToAlawBuffer(pcm8);
-      else {
+      if (remote.pt === 9) {
+        encoded = pcm16ToG722Buffer(pcm16);
+      } else if (remote.pt === 0) {
+        pcm8 = pcm8 || pcm16Resample(pcm16, 16000, 8000);
+        encoded = pcm16ToUlawBuffer(pcm8);
+      } else if (remote.pt === 8) {
+        pcm8 = pcm8 || pcm16Resample(pcm16, 16000, 8000);
+        encoded = pcm16ToAlawBuffer(pcm8);
+      } else {
         endReason = 'Unsupported codec';
         clearTimeout(timer);
         return reject(new Error('Geen ondersteunde codec'));
       }
+      // PCM buffers are no longer needed after encoding; free references so
+      // the garbage collector can reclaim the memory promptly.
+      pcm16 = null;
+      pcm8 = null;
       const contactHeader = Array.isArray(res.headers.contact) ? res.headers.contact[0] : res.headers.contact;
       const remoteTarget = contactHeader && (contactHeader.uri || contactHeader);
       // ACK


### PR DESCRIPTION
## Summary
- Lazily generate 8 kHz PCM data only when required by the negotiated codec
- Drop PCM buffers after encoding to free memory sooner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b308dc14f0833090b27ca4d694da3f