### PR TITLE
Handle retransmitted SIP 200 OK responses

### DIFF
--- a/lib/sip_call_play.cjs
+++ b/lib/sip_call_play.cjs
@@ -275,6 +275,29 @@ async function callOnce(cfg) {
       }, invite_timeout * 1000);
 
     const handle2xx = (res) => {
+      // Some SIP servers retransmit the final 2xx response until they
+      // receive a matching ACK. If we've already set up the RTP stream,
+      // simply resend the ACK and ignore the duplicate response to prevent
+      // re-processing (which previously caused null dereferences).
+      if (rtpStream) {
+        const contactHeader = Array.isArray(res.headers.contact) ? res.headers.contact[0] : res.headers.contact;
+        const remoteTarget = contactHeader && (contactHeader.uri || contactHeader);
+        const ack = {
+          method: 'ACK',
+          uri: remoteTarget || invite.uri,
+          headers: {
+            to: res.headers.to,
+            from: invite.headers.from,
+            'call-id': callId,
+            cseq: { method: 'ACK', seq: cseq },
+            via: [ buildVia(public_ip, public_sip_port, transport) ],
+            contact: invite.headers.contact
+          }
+        };
+        sip.send(ack);
+        return;
+      }
+
       const fallbackIp = (sip_proxy || sip_domain).replace(/^sip:/, '').split(':')[0];
       const remote = parseRemoteRtp(res.content, fallbackIp);
       if (!remote) {
@@ -310,7 +333,7 @@ async function callOnce(cfg) {
           to: res.headers.to,
           from: invite.headers.from,
           'call-id': callId,
-          cseq: { method: 'ACK', seq: ++cseq },
+          cseq: { method: 'ACK', seq: cseq },
           via: [ buildVia(public_ip, public_sip_port, transport) ],
           contact: invite.headers.contact
         }


### PR DESCRIPTION
## Summary
- avoid re-processing duplicate 2xx INVITE responses by resending ACK only
- send ACK using the original CSeq number

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b30b2b0ee883308fa2d366efa4a0e9