### PR TITLE
Handle unexpected SIP requests

### DIFF
--- a/lib/sip_call_play.cjs
+++ b/lib/sip_call_play.cjs
@@ -394,6 +394,11 @@ async function callOnce(cfg) {
               reason: endReason
             });
           }, 100);
+        } else if (req.method !== 'ACK') {
+          // Respond with 200 OK to unexpected requests (e.g. NOTIFY)
+          logger('info', `Received ${req.method}`);
+          try { sip.send(sip.makeResponse(req, 200, 'OK')); } catch (_) {}
+          logger('info', `Send 200 OK for ${req.method}`);
         }
       });
     };


### PR DESCRIPTION
## Summary
- reply with 200 OK to unhandled SIP requests to avoid stack errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30cf1ec308330b1407e3136728578