### PR TITLE
Replace unsupported voice option

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -111,8 +111,8 @@
         tts_quality: 'normal'
       };
       const voiceOptions = {
-        male: ['alloy','onyx'],
-        female: ['shimmer','verse']
+        male: ['alloy','ash','echo','fable','onyx','sage'],
+        female: ['shimmer','nova','coral']
       };
       let savedVoice = defaults.voice;
       function updateVoiceOptions() {


### PR DESCRIPTION
## Summary
- remove unsupported `verse` voice choice from settings UI
- add `nova` as supported option for female voices
- include full set of supported voices for each gender

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b586b1c82c83308cd11a9c6e60dab1