### PR TITLE
feat: add TTS speed setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Uiteraard des te groter de geluidsfile des te langer het duurt voor de start van
 
 Belangrijke meldingen kan je dus het beste al in het juiste formaat in soundboard of elders klaar hebben staan.
 Geconverteerde geluidsbestanden worden standaard 3 dagen in cache bewaard (instelbaar via de app-instellingen) zodat vaak gebruikte bestanden niet telkens opnieuw geconverteerd hoeven te worden.
+De spreek-snelheid van de TTS stem kan via de app-instellingen worden ingesteld op langzaam, normaal of snel.

--- a/app.js
+++ b/app.js
@@ -293,11 +293,17 @@ class HomeyPhoneHomeApp extends Homey.App {
     const quality = this.homey.settings.get('tts_quality') || 'normal';
     const model = quality === 'high' ? 'tts-1-hd' : 'gpt-4o-mini-tts';
     const voice = this.homey.settings.get('voice') || 'alloy';
+    const speedSetting = this.homey.settings.get('tts_speed') || 'normal';
+    const speedMap = { slow: 0.75, normal: 1, fast: 1.25 };
+    const speed = speedMap[speedSetting] !== undefined
+      ? speedMap[speedSetting]
+      : Math.min(4, Math.max(0.25, Number(speedSetting)));
     const speech = await client.audio.speech.create({
       model,
       voice,
       input: text,
-      format: 'wav'
+      format: 'wav',
+      speed
     });
     const buffer = Buffer.from(await speech.arrayBuffer());
     const tmp = path.join(os.tmpdir(), `tts_${Date.now()}.wav`);

--- a/settings/index.html
+++ b/settings/index.html
@@ -94,12 +94,19 @@
         <option value="high">High</option>
       </select>
     </label>
+    <label>TTS Speed
+      <select id="tts_speed">
+        <option value="slow">Slow</option>
+        <option value="normal">Normal</option>
+        <option value="fast">Fast</option>
+      </select>
+    </label>
     <button type="submit">Save</button>
     <button type="button" id="clear-cache">Clear cache</button>
   </form>
   <script>
     function onHomeyReady(Homey) {
-      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port','cache_days','openai_api_key','voice_gender','voice','tts_quality'];
+      const fields = ['sip_domain','sip_proxy','username','auth_id','password','realm','display_name','from_user','local_ip','sip_transport','local_sip_port','local_rtp_port','codec','expires_sec','invite_timeout','stun_server','stun_port','cache_days','openai_api_key','voice_gender','voice','tts_quality','tts_speed'];
       const defaults = {
         sip_transport: 'UDP',
         codec: 'AUTO',
@@ -108,7 +115,8 @@
         cache_days: 3,
         voice_gender: 'male',
         voice: 'alloy',
-        tts_quality: 'normal'
+        tts_quality: 'normal',
+        tts_speed: 'normal'
       };
       const voiceOptions = {
         male: ['alloy','ash','echo','fable','onyx','sage'],


### PR DESCRIPTION
## Summary
- allow customizing OpenAI TTS speed via selectable slow/normal/fast presets
- expose TTS speed presets in the app's settings page
- document that TTS speech rate can now be set to slow, normal or fast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b596389a6083309eb182932160e7a4