### PR TITLE
Add tabbed sections for SIP and ChatGPT settings

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -9,100 +9,113 @@
     label { display: block; margin-top: 10px; }
     input { width: 100%; box-sizing: border-box; }
     button { margin-top: 20px; }
+    .tabs { margin-bottom: 20px; }
+    .tab { margin-right: 10px; padding: 10px; cursor: pointer; }
+    .tab.active { font-weight: bold; border-bottom: 2px solid #000; }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
   </style>
 </head>
 <body>
-  <h1>SIP Settings</h1>
+  <h1>Settings</h1>
+  <div class="tabs">
+    <button type="button" class="tab active" data-target="sip-settings">SIP Settings</button>
+    <button type="button" class="tab" data-target="chatgpt-settings">ChatGPT Settings</button>
+  </div>
   <form id="settings-form">
-    <label>SIP Domain/Registrar
-      <input id="sip_domain" type="text" />
-    </label>
-    <label>SIP Proxy/Request-URI host (optional)
-      <input id="sip_proxy" type="text" />
-    </label>
-    <label>Username
-      <input id="username" type="text" />
-    </label>
-    <label>Authentication ID (optional)
-      <input id="auth_id" type="text" />
-    </label>
-    <label>Password
-      <input id="password" type="password" />
-    </label>
-    <label>Realm (optional)
-      <input id="realm" type="text" />
-    </label>
-    <label>Display name (From)
-      <input id="display_name" type="text" />
-    </label>
-    <label>From user
-      <input id="from_user" type="text" />
-    </label>
-    <label>Local IP (Homey)
-      <input id="local_ip" type="text" />
-    </label>
-    <label>SIP Transport
-      <select id="sip_transport">
-        <option value="UDP">UDP</option>
-        <option value="TCP">TCP</option>
-      </select>
-    </label>
-    <label>Local SIP port
-      <input id="local_sip_port" type="number" />
-    </label>
-    <label>Local RTP port
-      <input id="local_rtp_port" type="number" />
-    </label>
-    <label>Codec
-      <select id="codec">
-        <option value="AUTO">AUTO (prefer PCMA)</option>
-        <option value="PCMU">PCMU (G711u)</option>
-        <option value="PCMA">PCMA (G711a)</option>
-        <option value="G722">G722</option>
-      </select>
-    </label>
-    <label>REGISTER Expires (s)
-      <input id="expires_sec" type="number" />
-    </label>
-    <label>Invite timeout (s)
-      <input id="invite_timeout" type="number" />
-    </label>
-    <label>STUN server (optional)
-      <input id="stun_server" type="text" />
-    </label>
-    <label>STUN port
-      <input id="stun_port" type="number" />
-    </label>
-    <label>Cache days
-      <input id="cache_days" type="number" />
-    </label>
-    <label>OpenAI API Key
-      <input id="openai_api_key" type="password" />
-    </label>
-    <label>Voice Gender
-      <select id="voice_gender">
-        <option value="male">Male</option>
-        <option value="female">Female</option>
-      </select>
-    </label>
-    <label>Voice
-      <select id="voice"></select>
-    </label>
-    <label>TTS Quality
-      <select id="tts_quality">
-        <option value="normal">Normal</option>
-        <option value="high">High</option>
-      </select>
-    </label>
-    <label>TTS Speed
-      <select id="tts_speed">
-        <option value="slow">Slow</option>
-        <option value="normal">Normal</option>
-        <option value="fast">Fast</option>
-      </select>
-    </label>
+    <div id="sip-settings" class="tab-content active">
+      <label>SIP Domain/Registrar
+        <input id="sip_domain" type="text" />
+      </label>
+      <label>SIP Proxy/Request-URI host (optional)
+        <input id="sip_proxy" type="text" />
+      </label>
+      <label>Username
+        <input id="username" type="text" />
+      </label>
+      <label>Authentication ID (optional)
+        <input id="auth_id" type="text" />
+      </label>
+      <label>Password
+        <input id="password" type="password" />
+      </label>
+      <label>Realm (optional)
+        <input id="realm" type="text" />
+      </label>
+      <label>Display name (From)
+        <input id="display_name" type="text" />
+      </label>
+      <label>From user
+        <input id="from_user" type="text" />
+      </label>
+      <label>Local IP (Homey)
+        <input id="local_ip" type="text" />
+      </label>
+      <label>SIP Transport
+        <select id="sip_transport">
+          <option value="UDP">UDP</option>
+          <option value="TCP">TCP</option>
+        </select>
+      </label>
+      <label>Local SIP port
+        <input id="local_sip_port" type="number" />
+      </label>
+      <label>Local RTP port
+        <input id="local_rtp_port" type="number" />
+      </label>
+      <label>Codec
+        <select id="codec">
+          <option value="AUTO">AUTO (prefer PCMA)</option>
+          <option value="PCMU">PCMU (G711u)</option>
+          <option value="PCMA">PCMA (G711a)</option>
+          <option value="G722">G722</option>
+        </select>
+      </label>
+      <label>REGISTER Expires (s)
+        <input id="expires_sec" type="number" />
+      </label>
+      <label>Invite timeout (s)
+        <input id="invite_timeout" type="number" />
+      </label>
+      <label>STUN server (optional)
+        <input id="stun_server" type="text" />
+      </label>
+      <label>STUN port
+        <input id="stun_port" type="number" />
+      </label>
+    </div>
+    <div id="chatgpt-settings" class="tab-content">
+      <label>Cache days
+        <input id="cache_days" type="number" />
+      </label>
+      <label>OpenAI API Key
+        <input id="openai_api_key" type="password" />
+      </label>
+      <label>Voice Gender
+        <select id="voice_gender">
+          <option value="male">Male</option>
+          <option value="female">Female</option>
+        </select>
+      </label>
+      <label>Voice
+        <select id="voice"></select>
+      </label>
+      <label>TTS Quality
+        <select id="tts_quality">
+          <option value="normal">Normal</option>
+          <option value="high">High</option>
+        </select>
+      </label>
+      <label>TTS Speed
+        <select id="tts_speed">
+          <option value="slow">Slow</option>
+          <option value="normal">Normal</option>
+          <option value="fast">Fast</option>
+        </select>
+      </label>
+      <button type="button" id="clear-cache">Clear cache</button>
+    </div>
     <button type="submit">Save</button>
-    <button type="button" id="clear-cache">Clear cache</button>
   </form>
   <script>
     function onHomeyReady(Homey) {
@@ -160,6 +173,14 @@
       });
       document.getElementById('voice').addEventListener('change', () => {
         savedVoice = document.getElementById('voice').value;
+      });
+      document.querySelectorAll('.tab').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('.tab').forEach(b => b.classList.remove('active'));
+          document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+          btn.classList.add('active');
+          document.getElementById(btn.dataset.target).classList.add('active');
+        });
       });
       document.getElementById('settings-form').addEventListener('submit', e => {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- Add tab navigation to settings page separating SIP and ChatGPT configuration
- Include JavaScript to switch between tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a11f285c83308d66740b45bdda6c