### PR TITLE
fix: send multipart headers when uploading to Soundboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -327,7 +327,7 @@ class HomeyPhoneHomeApp extends Homey.App {
     } catch (e) {
       this.error('Soundboard form length failed:', e.message || e);
     }
-    await sb.post('/sounds', form, headers);
+    await sb.post('/sounds', form, null, { headers });
   }
   async _downloadToFile(url, destPath) {
     const client = url.startsWith('https')?https:http;


### PR DESCRIPTION
## Summary
- forward form-data headers (incl. content-length) to Soundboard API to allow WAV upload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3dbc7208330a0a688aa1aae9c26