### PR TITLE
Refactor SIP config and harden audio pipeline

### DIFF
--- a/app.js
+++ b/app.js
@@ -52,25 +52,7 @@ class HomeyPhoneHomeApp extends Homey.App {
       const number = String(args.number || '').trim();
       if (!number) throw new Error('Geen nummer opgegeven');
 
-      const cfg = {
-        sip_domain: this.homey.settings.get('sip_domain'),
-        sip_proxy: this.homey.settings.get('sip_proxy') || null,
-        username: this.homey.settings.get('username'),
-        auth_id: this.homey.settings.get('auth_id') || this.homey.settings.get('username'),
-        password: this.homey.settings.get('password'),
-        realm: this.homey.settings.get('realm') || '',
-        display_name: this.homey.settings.get('display_name') || 'HomeyBot',
-        from_user: this.homey.settings.get('from_user') || this.homey.settings.get('username'),
-        local_ip: this.homey.settings.get('local_ip'),
-        sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
-        local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
-        local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
-        codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
-        expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
-        invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
-        stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
-        stun_port: Number(this.homey.settings.get('stun_port') || 19302)
-      };
+      const cfg = this._getSipConfig();
 
       const to = number.includes('@') ? number : `${number}@${cfg.sip_domain}`;
 
@@ -101,6 +83,8 @@ class HomeyPhoneHomeApp extends Homey.App {
           status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'
         });
         throw e;
+      } finally {
+        if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
       }
 
       await this._triggerCompleted.trigger({
@@ -117,25 +101,7 @@ class HomeyPhoneHomeApp extends Homey.App {
       const number = String(args.number || '').trim();
       if (!number) throw new Error('Geen nummer opgegeven');
 
-      const cfg = {
-        sip_domain: this.homey.settings.get('sip_domain'),
-        sip_proxy: this.homey.settings.get('sip_proxy') || null,
-        username: this.homey.settings.get('username'),
-        auth_id: this.homey.settings.get('auth_id') || this.homey.settings.get('username'),
-        password: this.homey.settings.get('password'),
-        realm: this.homey.settings.get('realm') || '',
-        display_name: this.homey.settings.get('display_name') || 'HomeyBot',
-        from_user: this.homey.settings.get('from_user') || this.homey.settings.get('username'),
-        local_ip: this.homey.settings.get('local_ip'),
-        sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
-        local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
-        local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
-        codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
-        expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
-        invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
-        stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
-        stun_port: Number(this.homey.settings.get('stun_port') || 19302)
-      };
+      const cfg = this._getSipConfig();
 
       const to = number.includes('@') ? number : `${number}@${cfg.sip_domain}`;
 
@@ -165,6 +131,8 @@ class HomeyPhoneHomeApp extends Homey.App {
           status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'
         });
         throw e;
+      } finally {
+        if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
       }
 
     await this._triggerCompleted.trigger({
@@ -183,25 +151,7 @@ class HomeyPhoneHomeApp extends Homey.App {
       const text = String(args.text || '').trim();
       if (!text) throw new Error('Geen tekst opgegeven');
 
-      const cfg = {
-        sip_domain: this.homey.settings.get('sip_domain'),
-        sip_proxy: this.homey.settings.get('sip_proxy') || null,
-        username: this.homey.settings.get('username'),
-        auth_id: this.homey.settings.get('auth_id') || this.homey.settings.get('username'),
-        password: this.homey.settings.get('password'),
-        realm: this.homey.settings.get('realm') || '',
-        display_name: this.homey.settings.get('display_name') || 'HomeyBot',
-        from_user: this.homey.settings.get('from_user') || this.homey.settings.get('username'),
-        local_ip: this.homey.settings.get('local_ip'),
-        sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
-        local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
-        local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
-        codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
-        expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
-        invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
-        stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
-        stun_port: Number(this.homey.settings.get('stun_port') || 19302)
-      };
+      const cfg = this._getSipConfig();
 
       const to = number.includes('@') ? number : `${number}@${cfg.sip_domain}`;
 
@@ -229,6 +179,8 @@ class HomeyPhoneHomeApp extends Homey.App {
           status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'
         });
         throw e;
+      } finally {
+        if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
       }
 
       await this._triggerCompleted.trigger({
@@ -246,7 +198,11 @@ class HomeyPhoneHomeApp extends Homey.App {
       const name = String(args.name || '').trim() || `tts_${Date.now()}`;
       if (!text) throw new Error('Geen tekst opgegeven');
       const wavPath = await this._openAiTextToWav(text);
-      await this._saveToSoundboard(wavPath, name);
+      try {
+        await this._saveToSoundboard(wavPath, name);
+      } finally {
+        if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
+      }
       return true;
     });
   }
@@ -262,6 +218,28 @@ class HomeyPhoneHomeApp extends Homey.App {
     }
   }
 
+  _getSipConfig() {
+    return {
+      sip_domain: this.homey.settings.get('sip_domain'),
+      sip_proxy: this.homey.settings.get('sip_proxy') || null,
+      username: this.homey.settings.get('username'),
+      auth_id: this.homey.settings.get('auth_id') || this.homey.settings.get('username'),
+      password: this.homey.settings.get('password'),
+      realm: this.homey.settings.get('realm') || '',
+      display_name: this.homey.settings.get('display_name') || 'HomeyBot',
+      from_user: this.homey.settings.get('from_user') || this.homey.settings.get('username'),
+      local_ip: this.homey.settings.get('local_ip'),
+      sip_transport: (this.homey.settings.get('sip_transport') || 'UDP').toUpperCase(),
+      local_sip_port: Number(this.homey.settings.get('local_sip_port') || 5070),
+      local_rtp_port: Number(this.homey.settings.get('local_rtp_port') || 40000),
+      codec: (this.homey.settings.get('codec') || 'AUTO').toUpperCase(),
+      expires_sec: Number(this.homey.settings.get('expires_sec') || 300),
+      invite_timeout: Number(this.homey.settings.get('invite_timeout') || 45),
+      stun_server: this.homey.settings.get('stun_server') || 'stun.l.google.com',
+      stun_port: Number(this.homey.settings.get('stun_port') || 19302)
+    };
+  }
+
   async _resolveSoundboardToWav(soundArg) {
     const sb = this.homey.api.getApiApp('com.athom.soundboard');
     if (!await sb.getInstalled()) throw new Error('Soundboard app niet geïnstalleerd');
@@ -269,21 +247,29 @@ class HomeyPhoneHomeApp extends Homey.App {
     const sounds = Array.isArray(root) ? root : (root?.sounds || []);
     const s = sounds.find(x => x.id === soundArg.id || x.path === soundArg.id || x.name === soundArg.id);
     if (!s || !s.path) throw new Error('Soundboard geluid niet gevonden');
+    const safePath = path.posix.normalize(s.path).replace(/^\/+/, '');
+    if (safePath.startsWith('..')) throw new Error('Ongeldige soundboard pad');
     const localAddress = await this.homey.cloud.getLocalAddress();
-    const url = `http://${localAddress}/app/com.athom.soundboard/${s.path}`.replace(/\.\//g, '');
+    const url = `http://${localAddress}/app/com.athom.soundboard/${safePath}`;
     const dest = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
     await this._downloadToFile(url, dest);
     const cacheDays = Number(this.homey.settings.get('cache_days') || 3);
-    return await ensureWavPcm16Mono16k(dest, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)), cacheDays);
+    const out = await ensureWavPcm16Mono16k(dest, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)), cacheDays);
+    if (out !== dest) fs.unlink(dest, () => {});
+    return out;
   }
   async _ensureLocalWav(urlOrPath) {
     let local = urlOrPath;
+    let cleanup = false;
     if (/^https?:\/\//i.test(urlOrPath)) {
       local = path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
       await this._downloadToFile(urlOrPath, local);
+      cleanup = true;
     } else { if (!fs.existsSync(urlOrPath)) throw new Error('Bestand niet gevonden: '+urlOrPath); }
     const cacheDays = Number(this.homey.settings.get('cache_days') || 3);
-    return await ensureWavPcm16Mono16k(local, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)), cacheDays);
+    const out = await ensureWavPcm16Mono16k(local, (lvl,msg) => (lvl==='error'?this.error(msg):this.log(msg)), cacheDays);
+    if (cleanup && out !== local) fs.unlink(local, () => {});
+    return out;
   }
 
   async _openAiTextToWav(text) {
@@ -330,13 +316,21 @@ class HomeyPhoneHomeApp extends Homey.App {
     await sb.post('/sounds', form, null, { headers });
   }
   async _downloadToFile(url, destPath) {
-    const client = url.startsWith('https')?https:http;
-    await new Promise((resolve,reject)=>{
+    const client = url.startsWith('https') ? https : http;
+    await new Promise((resolve, reject) => {
       const file = fs.createWriteStream(destPath);
-      const req = client.get(url, res=>{
-        if (res.statusCode!==200) return reject(new Error('HTTP '+res.statusCode));
-        res.pipe(file); file.on('finish', ()=>file.close(resolve));
-      }); req.on('error', reject);
+      const cleanup = err => {
+        file.close(() => fs.unlink(destPath, () => {}));
+        reject(err);
+      };
+      const req = client.get(url, res => {
+        if (res.statusCode !== 200) return cleanup(new Error('HTTP ' + res.statusCode));
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+        file.on('error', cleanup);
+      });
+      req.on('error', cleanup);
+      req.setTimeout(15000, () => req.destroy(new Error('Request timeout')));
     });
   }
 }

--- a/lib/parseRemoteRtp.test.cjs
+++ b/lib/parseRemoteRtp.test.cjs
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('assert');
+
+const { parseRemoteRtp, buildSdpOffer } = require('./sip_call_play.cjs');
+
+test('parseRemoteRtp extracts ip, port and pt', () => {
+  const sdp = buildSdpOffer('1.2.3.4', 5555, 'AUTO');
+  const info = parseRemoteRtp(sdp, '1.2.3.4');
+  assert.deepStrictEqual(info, { ip: '1.2.3.4', port: 5555, pt: 9 });
+});
+
+test('parseRemoteRtp returns null for invalid sdp', () => {
+  assert.strictEqual(parseRemoteRtp('invalid', '1.2.3.4'), null);
+});

--- a/lib/sip_call_play.cjs
+++ b/lib/sip_call_play.cjs
@@ -258,7 +258,7 @@ async function callOnce(cfg) {
     let callId = invite.headers['call-id'];
     let cseq = invite.headers.cseq.seq;
 
-    let pcm16 = readWavPcm16Mono16k(wavPath);
+    let pcm16 = await readWavPcm16Mono16k(wavPath);
     // `pcm8` is only needed when the remote side negotiates an 8 kHz
     // codec (PCMU/PCMA). Lazily derive it from the 16 kHz buffer to avoid
     // holding two large PCM arrays in memory when it isn't required.
@@ -506,4 +506,4 @@ function startRtpStream(encoded, localIp, localPort, remote, repeats, onDone) {
   };
 }
 
-module.exports = { callOnce, parseAuthHeader, buildSdpOffer };
+module.exports = { callOnce, parseAuthHeader, buildSdpOffer, parseRemoteRtp };

--- a/lib/wav_utils.cjs
+++ b/lib/wav_utils.cjs
@@ -11,8 +11,8 @@ let MPEGDecoder;
 let OggVorbisDecoder;
 let FlacDecoder;
 
-function readWavPcm16Mono(path, expectedRate) {
-  const buf = fs.readFileSync(path);
+async function readWavPcm16Mono(path, expectedRate) {
+  const buf = await fs.promises.readFile(path);
   if (buf.slice(0,4).toString() !== 'RIFF' || buf.slice(8,12).toString() !== 'WAVE') {
     throw new Error('Geen geldige WAV (RIFF/WAVE)');
   }
@@ -44,11 +44,11 @@ function readWavPcm16Mono(path, expectedRate) {
   return pcm;
 }
 
-function readWavPcm16Mono8k(path) {
+async function readWavPcm16Mono8k(path) {
   return readWavPcm16Mono(path, 8000);
 }
 
-function readWavPcm16Mono16k(path) {
+async function readWavPcm16Mono16k(path) {
   return readWavPcm16Mono(path, 16000);
 }
 
@@ -156,7 +156,7 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}, cacheD
 
   logger('info', `0%: controleer ${srcPath}`);
   try {
-    readWavPcm16Mono(srcPath, targetRate);
+    await readWavPcm16Mono(srcPath, targetRate);
     logger('info', '100%: geen conversie nodig');
     if (cacheFile) fs.copyFileSync(srcPath, cacheFile);
     return cacheFile || srcPath;
@@ -175,7 +175,7 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}, cacheD
         logger('info', '60%: WAV gedecodeerd');
         const dest = cacheFile || path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
         (targetRate===8000?writeWavPcm16Mono8k:writeWavPcm16Mono16k)(dest, pcm);
-        readWavPcm16Mono(dest, targetRate);
+        await readWavPcm16Mono(dest, targetRate);
         logger('info', '100%: conversie gereed');
         return dest;
       } catch (err) {
@@ -194,7 +194,7 @@ async function ensureWavPcm16Mono(srcPath, targetRate, logger = () => {}, cacheD
         logger('info', `60%: ${d.name} gedecodeerd`);
         const dest = cacheFile || path.join(os.tmpdir(), `voip_${Date.now()}.wav`);
         (targetRate===8000?writeWavPcm16Mono8k:writeWavPcm16Mono16k)(dest, pcm);
-        readWavPcm16Mono(dest, targetRate);
+        await readWavPcm16Mono(dest, targetRate);
         logger('info', '100%: conversie gereed');
         return dest;
       } catch (err) {

--- a/lib/wav_utils.test.cjs
+++ b/lib/wav_utils.test.cjs
@@ -11,7 +11,7 @@ test('ensureWavPcm16Mono8k converts mp3 to wav', async () => {
   const mp3 = path.join(os.tmpdir(), `tone_${Date.now()}.mp3`);
   fs.writeFileSync(mp3, Buffer.from(TONE_MP3_BASE64, 'base64'));
   const out = await ensureWavPcm16Mono8k(mp3);
-  const pcm = readWavPcm16Mono8k(out);
+  const pcm = await readWavPcm16Mono8k(out);
   assert.ok(pcm.length > 0);
   fs.unlinkSync(out);
   fs.unlinkSync(mp3);
@@ -31,7 +31,7 @@ test('ensureWavPcm16Mono8k handles mp3 with wav extension', async () => {
   const fakeWav = path.join(os.tmpdir(), `tone_${Date.now()}.wav`);
   fs.writeFileSync(fakeWav, Buffer.from(TONE_MP3_BASE64, 'base64'));
   const out = await ensureWavPcm16Mono8k(fakeWav);
-  const pcm = readWavPcm16Mono8k(out);
+  const pcm = await readWavPcm16Mono8k(out);
   assert.ok(pcm.length > 0);
   fs.unlinkSync(out);
   fs.unlinkSync(fakeWav);
@@ -59,10 +59,14 @@ test('ensureWavPcm16Mono8k converts wav with different sample rate', async () =>
   fs.closeSync(fd);
 
   const out = await ensureWavPcm16Mono8k(wav);
-  const pcm = readWavPcm16Mono8k(out);
+  const pcm = await readWavPcm16Mono8k(out);
   assert.ok(pcm.length > 0);
   fs.unlinkSync(out);
   fs.unlinkSync(wav);
+});
+
+test('ensureWavPcm16Mono8k throws on missing file', async () => {
+  await assert.rejects(() => ensureWavPcm16Mono8k('/no/such/file.wav'));
 });
 
 test('ensureWavPcm16Mono8k uses cache when available', async () => {


### PR DESCRIPTION
## Summary
- centralize SIP configuration assembly
- sanitize soundboard paths and clean up temporary WAV files
- add request timeout handling and asynchronous WAV parsing
- expand tests for RTP parsing and missing audio files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4c5dcfc8330ad5550759307813f