### PR TITLE
Update app identifier to com.phonehome

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,5 +1,5 @@
 {
-  "id": "com.homey.phonehome",
+  "id": "com.phonehome",
   "sdk": 3,
   "name": {
     "en": "Homey Phone Home",

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
-  "id": "com.homey.phonehome",
+  "id": "com.phonehome",
   "sdk": 3,
   "name": {
     "en": "Homey Phone Home",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "com.homey.phonehome",
+  "name": "com.phonehome",
   "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "com.homey.phonehome",
+      "name": "com.phonehome",
       "version": "0.1.1",
       "dependencies": {
         "@wasm-audio-decoders/flac": "^0.2.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "com.homey.phonehome",
+  "name": "com.phonehome",
   "version": "0.1.1",
   "description": "Homey app: place a SIP call and play a Soundboard/URL audio",
   "main": "app.js",


### PR DESCRIPTION
## Summary
- rename the app package name to `com.phonehome`
- update Homey app manifests to use the new identifier

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5055ce540833088349bdc914cd24c