### PR TITLE
Improve call completed flow card formatting

### DIFF
--- a/.homeycompose/flow/triggers/call_completed.json
+++ b/.homeycompose/flow/triggers/call_completed.json
@@ -14,18 +14,18 @@
     "ko": "통화 완료 (상태)"
   },
   "titleFormatted": {
-    "en": "Call completed: [[status]]",
-    "nl": "Call afgerond: [[status]]",
-    "da": "Opkaldet fuldført: [[status]]",
-    "de": "Anruf abgeschlossen: [[status]]",
-    "es": "Llamada completada: [[status]]",
-    "fr": "Appel terminé : [[status]]",
-    "it": "Chiamata completata: [[status]]",
-    "no": "Samtale fullført: [[status]]",
-    "sv": "Samtal slutfört: [[status]]",
-    "pl": "Połączenie zakończone: [[status]]",
-    "ru": "Вызов завершён: [[status]]",
-    "ko": "통화 완료: [[status]]"
+    "en": "Call with [[callee]] completed: [[status]] (reason: [[reason]], duration [[duurMs]] ms)",
+    "nl": "Call met [[callee]] afgerond: [[status]] (reden: [[reason]], duur [[duurMs]] ms)",
+    "da": "Opkald med [[callee]] fuldført: [[status]] (årsag: [[reason]], varighed [[duurMs]] ms)",
+    "de": "Anruf mit [[callee]] abgeschlossen: [[status]] (Grund: [[reason]], Dauer [[duurMs]] ms)",
+    "es": "Llamada con [[callee]] completada: [[status]] (motivo: [[reason]], duración [[duurMs]] ms)",
+    "fr": "Appel avec [[callee]] terminé : [[status]] (raison : [[reason]], durée [[duurMs]] ms)",
+    "it": "Chiamata con [[callee]] completata: [[status]] (motivo: [[reason]], durata [[duurMs]] ms)",
+    "no": "Samtale med [[callee]] fullført: [[status]] (årsak: [[reason]], varighet [[duurMs]] ms)",
+    "sv": "Samtal med [[callee]] slutfört: [[status]] (orsak: [[reason]], varaktighet [[duurMs]] ms)",
+    "pl": "Połączenie z [[callee]] zakończone: [[status]] (powód: [[reason]], czas trwania [[duurMs]] ms)",
+    "ru": "Вызов с [[callee]] завершён: [[status]] (причина: [[reason]], длительность [[duurMs]] мс)",
+    "ko": "[[callee]]와의 통화 완료: [[status]] (이유: [[reason]], 통화 시간 [[duurMs]]ms)"
   },
   "tokens": [
     {

--- a/app.json
+++ b/app.json
@@ -437,18 +437,18 @@
           "ko": "통화 완료 (상태)"
         },
         "titleFormatted": {
-          "en": "Call completed: [[status]]",
-          "nl": "Call afgerond: [[status]]",
-          "da": "Opkaldet fuldført: [[status]]",
-          "de": "Anruf abgeschlossen: [[status]]",
-          "es": "Llamada completada: [[status]]",
-          "fr": "Appel terminé : [[status]]",
-          "it": "Chiamata completata: [[status]]",
-          "no": "Samtale fullført: [[status]]",
-          "sv": "Samtal slutfört: [[status]]",
-          "pl": "Połączenie zakończone: [[status]]",
-          "ru": "Вызов завершён: [[status]]",
-          "ko": "통화 완료: [[status]]"
+          "en": "Call with [[callee]] completed: [[status]] (reason: [[reason]], duration [[duurMs]] ms)",
+          "nl": "Call met [[callee]] afgerond: [[status]] (reden: [[reason]], duur [[duurMs]] ms)",
+          "da": "Opkald med [[callee]] fuldført: [[status]] (årsag: [[reason]], varighed [[duurMs]] ms)",
+          "de": "Anruf mit [[callee]] abgeschlossen: [[status]] (Grund: [[reason]], Dauer [[duurMs]] ms)",
+          "es": "Llamada con [[callee]] completada: [[status]] (motivo: [[reason]], duración [[duurMs]] ms)",
+          "fr": "Appel avec [[callee]] terminé : [[status]] (raison : [[reason]], durée [[duurMs]] ms)",
+          "it": "Chiamata con [[callee]] completata: [[status]] (motivo: [[reason]], durata [[duurMs]] ms)",
+          "no": "Samtale med [[callee]] fullført: [[status]] (årsak: [[reason]], varighet [[duurMs]] ms)",
+          "sv": "Samtal med [[callee]] slutfört: [[status]] (orsak: [[reason]], varaktighet [[duurMs]] ms)",
+          "pl": "Połączenie z [[callee]] zakończone: [[status]] (powód: [[reason]], czas trwania [[duurMs]] ms)",
+          "ru": "Вызов с [[callee]] завершён: [[status]] (причина: [[reason]], длительность [[duurMs]] мс)",
+          "ko": "[[callee]]와의 통화 완료: [[status]] (이유: [[reason]], 통화 시간 [[duurMs]]ms)"
         },
         "tokens": [
           {


### PR DESCRIPTION
## Summary
- expand the "Call completed" trigger's formatted title to include the callee, status, reason, and duration tokens across all locales

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d50b8db8e08330955aa8d38e0f4990