### PR TITLE
Fix module format for Homey runtime

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,13 +1,13 @@
-import Homey from 'homey';
-import path from 'path';
-import fs from 'fs';
-import os from 'os';
-import http from 'http';
-import https from 'https';
-import OpenAI from 'openai';
-import FormData from 'form-data';
-import sipCallPlay from './lib/sip_call_play.cjs';
-import wavUtils from './lib/wav_utils.cjs';
+const Homey = require('homey');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const http = require('http');
+const https = require('https');
+const OpenAI = require('openai');
+const FormData = require('form-data');
+const sipCallPlay = require('./lib/sip_call_play.cjs');
+const wavUtils = require('./lib/wav_utils.cjs');
 
 const { callOnce } = sipCallPlay;
 const { ensureWavPcm16Mono16k } = wavUtils;
@@ -334,4 +334,4 @@ class HomeyPhoneHomeApp extends Homey.App {
     });
   }
 }
-export default HomeyPhoneHomeApp;
+module.exports = HomeyPhoneHomeApp;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.1",
   "description": "Homey app: place a SIP call and play a Soundboard/URL audio",
   "main": "app.js",
-  "type": "module",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
## Summary
- replace top-level ESM imports/exports in the app entrypoint with CommonJS requires so the Homey runtime can execute it
- rely on the default CommonJS module resolution by removing the `type: module` flag from package.json

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5591123648330b70dbd99eeba9f1b