### PR TITLE
Add filtering options to call completed trigger

### DIFF
--- a/.homeycompose/flow/triggers/call_completed.json
+++ b/.homeycompose/flow/triggers/call_completed.json
@@ -27,6 +27,145 @@
     "ru": "Вызов с [[callee]] завершён: [[status]] (причина: [[reason]], длительность [[duurMs]] мс)",
     "ko": "[[callee]]와의 통화 완료: [[status]] (이유: [[reason]], 통화 시간 [[duurMs]]ms)"
   },
+  "args": [
+    {
+      "name": "status",
+      "type": "dropdown",
+      "title": {
+        "en": "Status",
+        "nl": "Status",
+        "da": "Status",
+        "de": "Status",
+        "es": "Estado",
+        "fr": "Statut",
+        "it": "Stato",
+        "no": "Status",
+        "sv": "Status",
+        "pl": "Status",
+        "ru": "Статус",
+        "ko": "상태"
+      },
+      "values": [
+        {
+          "id": "any",
+          "label": {
+            "en": "Any status",
+            "nl": "Elke status",
+            "da": "Enhver status",
+            "de": "Beliebiger Status",
+            "es": "Cualquier estado",
+            "fr": "N'importe quel statut",
+            "it": "Qualsiasi stato",
+            "no": "Enhver status",
+            "sv": "Valfri status",
+            "pl": "Dowolny status",
+            "ru": "Любой статус",
+            "ko": "모든 상태"
+          }
+        },
+        {
+          "id": "answered",
+          "label": {
+            "en": "Answered",
+            "nl": "Beantwoord",
+            "da": "Besvaret",
+            "de": "Beantwortet",
+            "es": "Contestada",
+            "fr": "Répondu",
+            "it": "Risposta",
+            "no": "Besvart",
+            "sv": "Besvarad",
+            "pl": "Odebrano",
+            "ru": "Отвечен",
+            "ko": "응답됨"
+          }
+        },
+        {
+          "id": "busy",
+          "label": {
+            "en": "Busy",
+            "nl": "In gesprek",
+            "da": "Optaget",
+            "de": "Besetzt",
+            "es": "Ocupado",
+            "fr": "Occupé",
+            "it": "Occupato",
+            "no": "Opptatt",
+            "sv": "Upptaget",
+            "pl": "Zajęty",
+            "ru": "Занято",
+            "ko": "통화중"
+          }
+        },
+        {
+          "id": "no-answer",
+          "label": {
+            "en": "No answer",
+            "nl": "Geen antwoord",
+            "da": "Intet svar",
+            "de": "Keine Antwort",
+            "es": "Sin respuesta",
+            "fr": "Pas de réponse",
+            "it": "Nessuna risposta",
+            "no": "Ingen svar",
+            "sv": "Inget svar",
+            "pl": "Brak odpowiedzi",
+            "ru": "Нет ответа",
+            "ko": "응답 없음"
+          }
+        },
+        {
+          "id": "failed",
+          "label": {
+            "en": "Failed",
+            "nl": "Mislukt",
+            "da": "Mislykkedes",
+            "de": "Fehlgeschlagen",
+            "es": "Falló",
+            "fr": "Échoué",
+            "it": "Fallito",
+            "no": "Feilet",
+            "sv": "Misslyckades",
+            "pl": "Niepowodzenie",
+            "ru": "Неудачно",
+            "ko": "실패"
+          }
+        }
+      ]
+    },
+    {
+      "name": "callee",
+      "type": "text",
+      "title": {
+        "en": "Callee",
+        "nl": "Gebelde partij",
+        "da": "Modtager",
+        "de": "Angerufener",
+        "es": "Destinatario",
+        "fr": "Appelé",
+        "it": "Destinatario",
+        "no": "Mottaker",
+        "sv": "Mottagare",
+        "pl": "Odbierający",
+        "ru": "Абонент",
+        "ko": "수신자"
+      },
+      "placeholder": {
+        "en": "Leave empty for any callee",
+        "nl": "Laat leeg voor elke gebelde partij",
+        "da": "Tom for enhver modtager",
+        "de": "Leer lassen für jeden Angerufenen",
+        "es": "Dejar vacío para cualquier destinatario",
+        "fr": "Laisser vide pour tout destinataire",
+        "it": "Lascia vuoto per qualsiasi destinatario",
+        "no": "La tom for hvilken som helst mottaker",
+        "sv": "Lämna tomt för valfri mottagare",
+        "pl": "Pozostaw puste dla dowolnego odbiorcy",
+        "ru": "Оставьте пустым для любого абонента",
+        "ko": "모든 수신자에 대해 비워 두세요"
+      }
+    }
+  ],
   "tokens": [
     {
       "name": "status",

--- a/app.js
+++ b/app.js
@@ -20,6 +20,20 @@ class HomeyPhoneHomeApp extends Homey.App {
 
     this._triggerCompleted = this.homey.flow.getTriggerCard('call_completed');
 
+    this._triggerCompleted.registerRunListener(async (args, state) => {
+      const statusFilter = args.status && args.status.id ? args.status.id : args.status;
+      if (statusFilter && statusFilter !== 'any') {
+        if (!state || state.status !== statusFilter) return false;
+      }
+
+      const calleeFilter = String(args.callee || '').trim();
+      if (calleeFilter) {
+        if (!state || String(state.callee || '').trim() !== calleeFilter) return false;
+      }
+
+      return true;
+    });
+
     this.homey.on('clear_cache', async (_data, callback) => {
       try {
         const cacheDir = path.join(os.tmpdir(), 'voip_cache');
@@ -79,20 +93,25 @@ class HomeyPhoneHomeApp extends Homey.App {
           logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
         });
       } catch (e) {
-        await this._triggerCompleted.trigger({
-          status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'
-        });
+        const tokens = {
+          status: 'failed',
+          duurMs: 0,
+          callee: number,
+          reason: e.message || 'unknown'
+        };
+        await this._triggerCompleted.trigger(tokens, tokens);
         throw e;
       } finally {
         if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
       }
 
-      await this._triggerCompleted.trigger({
+      const tokens = {
         status: result.status || 'answered',
-        duurMs: Number(result.durationMs||0),
+        duurMs: Number(result.durationMs || 0),
         callee: number,
         reason: result.reason || 'OK'
-      });
+      };
+      await this._triggerCompleted.trigger(tokens, tokens);
       return true;
     });
 
@@ -127,20 +146,25 @@ class HomeyPhoneHomeApp extends Homey.App {
           logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
         });
       } catch (e) {
-        await this._triggerCompleted.trigger({
-          status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'
-        });
+        const tokens = {
+          status: 'failed',
+          duurMs: 0,
+          callee: number,
+          reason: e.message || 'unknown'
+        };
+        await this._triggerCompleted.trigger(tokens, tokens);
         throw e;
       } finally {
         if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
       }
 
-    await this._triggerCompleted.trigger({
-      status: result.status || 'answered',
-      duurMs: Number(result.durationMs||0),
-      callee: number,
-      reason: result.reason || 'OK'
-    });
+      const tokens = {
+        status: result.status || 'answered',
+        duurMs: Number(result.durationMs || 0),
+        callee: number,
+        reason: result.reason || 'OK'
+      };
+      await this._triggerCompleted.trigger(tokens, tokens);
     return true;
   });
 
@@ -175,20 +199,25 @@ class HomeyPhoneHomeApp extends Homey.App {
           logger: (lvl, msg) => (lvl==='error'?this.error(msg):this.log(msg))
         });
       } catch (e) {
-        await this._triggerCompleted.trigger({
-          status: 'failed', duurMs: 0, callee: number, reason: e.message||'unknown'
-        });
+        const tokens = {
+          status: 'failed',
+          duurMs: 0,
+          callee: number,
+          reason: e.message || 'unknown'
+        };
+        await this._triggerCompleted.trigger(tokens, tokens);
         throw e;
       } finally {
         if (wavPath.startsWith(os.tmpdir())) fs.unlink(wavPath, () => {});
       }
 
-      await this._triggerCompleted.trigger({
+      const tokens = {
         status: result.status || 'answered',
-        duurMs: Number(result.durationMs||0),
+        duurMs: Number(result.durationMs || 0),
         callee: number,
         reason: result.reason || 'OK'
-      });
+      };
+      await this._triggerCompleted.trigger(tokens, tokens);
       return true;
     });
 

--- a/app.json
+++ b/app.json
@@ -450,6 +450,145 @@
           "ru": "Вызов с [[callee]] завершён: [[status]] (причина: [[reason]], длительность [[duurMs]] мс)",
           "ko": "[[callee]]와의 통화 완료: [[status]] (이유: [[reason]], 통화 시간 [[duurMs]]ms)"
         },
+        "args": [
+          {
+            "name": "status",
+            "type": "dropdown",
+            "title": {
+              "en": "Status",
+              "nl": "Status",
+              "da": "Status",
+              "de": "Status",
+              "es": "Estado",
+              "fr": "Statut",
+              "it": "Stato",
+              "no": "Status",
+              "sv": "Status",
+              "pl": "Status",
+              "ru": "Статус",
+              "ko": "상태"
+            },
+            "values": [
+              {
+                "id": "any",
+                "label": {
+                  "en": "Any status",
+                  "nl": "Elke status",
+                  "da": "Enhver status",
+                  "de": "Beliebiger Status",
+                  "es": "Cualquier estado",
+                  "fr": "N'importe quel statut",
+                  "it": "Qualsiasi stato",
+                  "no": "Enhver status",
+                  "sv": "Valfri status",
+                  "pl": "Dowolny status",
+                  "ru": "Любой статус",
+                  "ko": "모든 상태"
+                }
+              },
+              {
+                "id": "answered",
+                "label": {
+                  "en": "Answered",
+                  "nl": "Beantwoord",
+                  "da": "Besvaret",
+                  "de": "Beantwortet",
+                  "es": "Contestada",
+                  "fr": "Répondu",
+                  "it": "Risposta",
+                  "no": "Besvart",
+                  "sv": "Besvarad",
+                  "pl": "Odebrano",
+                  "ru": "Отвечен",
+                  "ko": "응답됨"
+                }
+              },
+              {
+                "id": "busy",
+                "label": {
+                  "en": "Busy",
+                  "nl": "In gesprek",
+                  "da": "Optaget",
+                  "de": "Besetzt",
+                  "es": "Ocupado",
+                  "fr": "Occupé",
+                  "it": "Occupato",
+                  "no": "Opptatt",
+                  "sv": "Upptaget",
+                  "pl": "Zajęty",
+                  "ru": "Занято",
+                  "ko": "통화중"
+                }
+              },
+              {
+                "id": "no-answer",
+                "label": {
+                  "en": "No answer",
+                  "nl": "Geen antwoord",
+                  "da": "Intet svar",
+                  "de": "Keine Antwort",
+                  "es": "Sin respuesta",
+                  "fr": "Pas de réponse",
+                  "it": "Nessuna risposta",
+                  "no": "Ingen svar",
+                  "sv": "Inget svar",
+                  "pl": "Brak odpowiedzi",
+                  "ru": "Нет ответа",
+                  "ko": "응답 없음"
+                }
+              },
+              {
+                "id": "failed",
+                "label": {
+                  "en": "Failed",
+                  "nl": "Mislukt",
+                  "da": "Mislykkedes",
+                  "de": "Fehlgeschlagen",
+                  "es": "Falló",
+                  "fr": "Échoué",
+                  "it": "Fallito",
+                  "no": "Feilet",
+                  "sv": "Misslyckades",
+                  "pl": "Niepowodzenie",
+                  "ru": "Неудачно",
+                  "ko": "실패"
+                }
+              }
+            ]
+          },
+          {
+            "name": "callee",
+            "type": "text",
+            "title": {
+              "en": "Callee",
+              "nl": "Gebelde partij",
+              "da": "Modtager",
+              "de": "Angerufener",
+              "es": "Destinatario",
+              "fr": "Appelé",
+              "it": "Destinatario",
+              "no": "Mottaker",
+              "sv": "Mottagare",
+              "pl": "Odbierający",
+              "ru": "Абонент",
+              "ko": "수신자"
+            },
+            "placeholder": {
+              "en": "Leave empty for any callee",
+              "nl": "Laat leeg voor elke gebelde partij",
+              "da": "Tom for enhver modtager",
+              "de": "Leer lassen für jeden Angerufenen",
+              "es": "Dejar vacío para cualquier destinatario",
+              "fr": "Laisser vide pour tout destinataire",
+              "it": "Lascia vuoto per qualsiasi destinatario",
+              "no": "La tom for hvilken som helst mottaker",
+              "sv": "Lämna tomt för valfri mottagare",
+              "pl": "Pozostaw puste dla dowolnego odbiorcy",
+              "ru": "Оставьте пустым для любого абонента",
+              "ko": "모든 수신자에 대해 비워 두세요"
+            }
+          }
+        ],
         "tokens": [
           {
             "name": "status",


### PR DESCRIPTION
## Summary
- add status dropdown and callee text arguments to the call_completed flow trigger definition
- register a run listener and supply trigger state so the new arguments are respected
- update the compiled app.json manifest to include the new argument metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da788cb3b083309be6cf54c1ee8b23