### PR TITLE
Fix call_completed flow card reason token name

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,7 +97,7 @@ class HomeyPhoneHomeApp extends Homey.App {
           status: 'failed',
           duurMs: 0,
           callee: number,
-          reasonText: e.message || 'unknown'
+          reason: e.message || 'unknown'
         };
         await this._triggerCompleted.trigger(tokens, tokens);
         throw e;
@@ -109,7 +109,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         status: result.status || 'answered',
         duurMs: Number(result.durationMs || 0),
         callee: number,
-        reasonText: result.reason || 'OK'
+        reason: result.reason || 'OK'
       };
       await this._triggerCompleted.trigger(tokens, tokens);
       return true;
@@ -150,7 +150,7 @@ class HomeyPhoneHomeApp extends Homey.App {
           status: 'failed',
           duurMs: 0,
           callee: number,
-          reasonText: e.message || 'unknown'
+          reason: e.message || 'unknown'
         };
         await this._triggerCompleted.trigger(tokens, tokens);
         throw e;
@@ -162,7 +162,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         status: result.status || 'answered',
         duurMs: Number(result.durationMs || 0),
         callee: number,
-        reasonText: result.reason || 'OK'
+        reason: result.reason || 'OK'
       };
       await this._triggerCompleted.trigger(tokens, tokens);
     return true;
@@ -203,7 +203,7 @@ class HomeyPhoneHomeApp extends Homey.App {
           status: 'failed',
           duurMs: 0,
           callee: number,
-          reasonText: e.message || 'unknown'
+          reason: e.message || 'unknown'
         };
         await this._triggerCompleted.trigger(tokens, tokens);
         throw e;
@@ -215,7 +215,7 @@ class HomeyPhoneHomeApp extends Homey.App {
         status: result.status || 'answered',
         duurMs: Number(result.durationMs || 0),
         callee: number,
-        reasonText: result.reason || 'OK'
+        reason: result.reason || 'OK'
       };
       await this._triggerCompleted.trigger(tokens, tokens);
       return true;

--- a/app.json
+++ b/app.json
@@ -437,18 +437,18 @@
           "ko": "통화 완료 (상태)"
         },
         "titleFormatted": {
-          "en": "Call with [[callee]] completed: [[status]] (reason: [[reasonText]], duration [[duurMs]] ms)",
-          "nl": "Call met [[callee]] afgerond: [[status]] (reden: [[reasonText]], duur [[duurMs]] ms)",
-          "da": "Opkald med [[callee]] fuldført: [[status]] (årsag: [[reasonText]], varighed [[duurMs]] ms)",
-          "de": "Anruf mit [[callee]] abgeschlossen: [[status]] (Grund: [[reasonText]], Dauer [[duurMs]] ms)",
-          "es": "Llamada con [[callee]] completada: [[status]] (motivo: [[reasonText]], duración [[duurMs]] ms)",
-          "fr": "Appel avec [[callee]] terminé : [[status]] (raison : [[reasonText]], durée [[duurMs]] ms)",
-          "it": "Chiamata con [[callee]] completata: [[status]] (motivo: [[reasonText]], durata [[duurMs]] ms)",
-          "no": "Samtale med [[callee]] fullført: [[status]] (årsak: [[reasonText]], varighet [[duurMs]] ms)",
-          "sv": "Samtal med [[callee]] slutfört: [[status]] (orsak: [[reasonText]], varaktighet [[duurMs]] ms)",
-          "pl": "Połączenie z [[callee]] zakończone: [[status]] (powód: [[reasonText]], czas trwania [[duurMs]] ms)",
-          "ru": "Вызов с [[callee]] завершён: [[status]] (причина: [[reasonText]], длительность [[duurMs]] мс)",
-          "ko": "[[callee]]와의 통화 완료: [[status]] (이유: [[reasonText]], 통화 시간 [[duurMs]]ms)"
+          "en": "Call with [[callee]] completed: [[status]] (reason: [[reason]], duration [[duurMs]] ms)",
+          "nl": "Call met [[callee]] afgerond: [[status]] (reden: [[reason]], duur [[duurMs]] ms)",
+          "da": "Opkald med [[callee]] fuldført: [[status]] (årsag: [[reason]], varighed [[duurMs]] ms)",
+          "de": "Anruf mit [[callee]] abgeschlossen: [[status]] (Grund: [[reason]], Dauer [[duurMs]] ms)",
+          "es": "Llamada con [[callee]] completada: [[status]] (motivo: [[reason]], duración [[duurMs]] ms)",
+          "fr": "Appel avec [[callee]] terminé : [[status]] (raison : [[reason]], durée [[duurMs]] ms)",
+          "it": "Chiamata con [[callee]] completata: [[status]] (motivo: [[reason]], durata [[duurMs]] ms)",
+          "no": "Samtale med [[callee]] fullført: [[status]] (årsak: [[reason]], varighet [[duurMs]] ms)",
+          "sv": "Samtal med [[callee]] slutfört: [[status]] (orsak: [[reason]], varaktighet [[duurMs]] ms)",
+          "pl": "Połączenie z [[callee]] zakończone: [[status]] (powód: [[reason]], czas trwania [[duurMs]] ms)",
+          "ru": "Вызов с [[callee]] завершён: [[status]] (причина: [[reason]], длительность [[duurMs]] мс)",
+          "ko": "[[callee]]와의 통화 완료: [[status]] (이유: [[reason]], 통화 시간 [[duurMs]]ms)"
         },
         "args": [
           {
@@ -645,7 +645,7 @@
             }
           },
           {
-            "name": "reasonText",
+            "name": "reason",
             "type": "string",
             "title": {
               "en": "Reason / Cause",


### PR DESCRIPTION
## Summary
- align the `call_completed` trigger titleFormatted placeholders with a `reason` token instead of `reasonText`
- update runtime flow trigger payloads to emit the renamed `reason` token for all call outcomes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da8fe9c81083309c54bc142e10bb6a